### PR TITLE
Add wiki link to $info

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/jwMaxwell/Spike-2.git",
-    "gh_url": "https://github.com/jwMaxwell/Spike-2"
+    "gh_url": "https://github.com/jwMaxwell/Spike-2",
+    "wiki": "https://github.com/jwMaxwell/Spike-2/wiki"
   },
   "language": "node.js",
   "scripts": {

--- a/src/plugins/core/main.js
+++ b/src/plugins/core/main.js
@@ -153,7 +153,8 @@ const info = async (msg) => {
                   `Committed: ${new Date(parseInt(commit_response_obj.committedOn*1000)).toUTCString()}\n` +
                   `Language: ${package.language}\n` + 
                   `Creation date: ${package.created}\n` +
-                  `Repository: ${package.repository.gh_url}`;
+                  `Repository: ${package.repository.gh_url}\n` +
+                  `Wiki: ${package.repository.wiki}`;
   spikeKit.reply(
     spikeKit.createEmbed(
       `${package.fullName} info`,


### PR DESCRIPTION
<!-- Thanks for taking the time to work on a patch! Please fill in the following. -->
<!-- We'll be in touch if we need any other information. -->
<!-- Once submitted, follow this PR's progress on the project board. -->
<!-- Notes like this are comments and won't appear in the PR. -->

**Related bugs/feature requests**
<!-- e.g. Resolves #2 -->
<!-- New bullet point for each issue if there's more than one. -->
+ Resolves  #13 

**Describe the changes**
<!-- A clear, concise description of the changes. -->
+ Adds the wiki link to `package.json`
+ Adds line to `info` to display wiki link

**Expected behavior**
<!-- A clear, concise description of what you expect to happen. -->
`$info` now shows wiki link alongside existing information.

**Screenshots**
<!-- If applicable, add screenshots to help explain your fix. -->

**New npm dependencies**
<!-- If there are new npm dependencies, list them below with their versions -->
<!-- Make sure changes to package.json and package-lock.json are committed as well -->

**Testing Instructions**
<!-- Instructions to thoroughly test this patch. -->

1. Run the `info` command.
2. Verify that `Wiki: https://github.com/jwMaxwell/Spike-2/wiki` appears at the end of the info embed message.

**Additional context**
<!-- Add any other context about the PR here. -->
