### PR TITLE
Disable Announce Command

### DIFF
--- a/src/commands.js
+++ b/src/commands.js
@@ -13,7 +13,6 @@ const plugins = [
   require("./plugins/shop/main.js"),
   require("./plugins/enigma/main.js"),
   require("./plugins/spike-lisp/main.js"),
-  require("./plugins/adminAnnounce/main.js"),
   require("./plugins/challenges/main.js"),
 ];
 


### PR DESCRIPTION
<!-- Thanks for taking the time to work on a patch! Please fill in the following. -->
<!-- We'll be in touch if we need any other information. -->
<!-- Once submitted, follow this PR's progress on the project board. -->
<!-- Notes like this are comments and won't appear in the PR. -->

**Related bugs/feature requests**
<!-- e.g. Resolves #2 -->
<!-- New bullet point for each issue if there's more than one. -->
+ Resolves  #45

**Describe the changes**
<!-- A clear, concise description of the changes. -->
Disables the Admin Announce module. Admins felt this was an overreach, and rightfully so. Code remains in the code-base as a reference for future plugins.

**Expected behavior**
<!-- A clear, concise description of what you expect to happen. -->
The Admin Announce module should not function.

**Screenshots**
<!-- If applicable, add screenshots to help explain your fix. -->

**New npm dependencies**
<!-- If there are new npm dependencies, list them below with their versions -->
<!-- Make sure changes to package.json and package-lock.json are committed as well -->

**Testing Instructions**
<!-- Instructions to thoroughly test this patch. -->
- [ ] Run `%help` and make sure admin announce doesn't show up
- [ ] Make sure `%announce` and `%pendingannouncements` don't work
- [ ] Make sure no messages relating to Admin Announcement show up in the bot startup output

**Additional context**
<!-- Add any other context about the PR here. -->
