### PR TITLE
Paginate help menu with slugs

### DIFF
--- a/src/commands.js
+++ b/src/commands.js
@@ -39,11 +39,9 @@ const help = (args, message, PREFIX) => {
   if (!args) {
     // Default Help Screen
     console.log("Getting default help");
-    let messageText = `Use '${PREFIX}help [c]' or '${PREFIX}man [c]' to find more information about these commands.`;
+    let messageText = `Use the given help commands to learn more about each plugin and its commands.\nUse \`${PREFIX}help <command>\` to jump to info on that command.`;
     for (const plugin of plugins) {
-      messageText += `\n-------\n${plugin.NAME}\nby ${
-        plugin.AUTHOR
-      }\n\n${plugin.shortHelp(PREFIX)}`;
+      messageText += `\n-------\n"${plugin.NAME}" by ${plugin.AUTHOR}\n\`${PREFIX}help plugin ${plugin.SLUG}\``;
     }
     spikeKit.reply(
       spikeKit.createEmbed(
@@ -57,10 +55,27 @@ const help = (args, message, PREFIX) => {
     );
   } else {
     // Not default, so find the right plugin to get help from
+    const helpCommand = args.split(" ")[0].toLowerCase();
+    const helpArgs = args.substring(args.split(" ")[0].length).slice(1);
     for (const plugin of plugins) {
-      const helpCommand = args.split(" ")[0].toLowerCase();
-      const helpArgs = args.substring(args.split(" ")[0].length).slice(1);
-      if (plugin.COMMANDS.includes(helpCommand)) {
+      if (helpCommand === "plugin" && helpArgs == plugin.SLUG) {
+        console.log(`Getting plugin help for "${plugin.NAME}"`);
+        spikeKit.reply(
+          spikeKit.createEmbed(
+            `${plugin.NAME} Help`,
+            `${plugin.NAME}\nby ${
+              plugin.AUTHOR
+            }\nUse \`${PREFIX}help <command>\` for info on that command.\n\n${plugin.shortHelp(
+              PREFIX
+            )}`,
+            true,
+            message.author.username,
+            message.author.avatarURL()
+          ),
+          message
+        );
+        break;
+      } else if (plugin.COMMANDS.includes(helpCommand)) {
         console.log(
           `Getting help for ${PREFIX}${helpCommand} from "${plugin.NAME}"`
         );

--- a/src/plugins/adminAnnounce/main.js
+++ b/src/plugins/adminAnnounce/main.js
@@ -9,6 +9,7 @@ const { throwErr } = require("../../botErr.js");
 const { getConsts } = require("../../faccess.js");
 
 const NAME = "Admin Announcement";
+const SLUG = "admin-announcement";
 const AUTHOR = "Brandon Ingli";
 const COMMANDS = ["announce", "pendingannouncements"];
 
@@ -353,6 +354,7 @@ function onBotStart(bot) {
 
 module.exports = {
   NAME,
+  SLUG,
   shortHelp,
   AUTHOR,
   COMMANDS,

--- a/src/plugins/betting/main.js
+++ b/src/plugins/betting/main.js
@@ -10,6 +10,7 @@ const { getStudent, addBucks, getDat, getConsts } = require("../../faccess.js");
 const { throwErr } = require("../../botErr.js");
 
 const NAME = "Bet";
+const SLUG = "betting";
 const AUTHOR = "Joshua Maxwell and Brandon Ingli";
 const COMMANDS = ["bet", "endbet", "activebets"];
 
@@ -580,6 +581,7 @@ function onBotStart(bot) {
 
 module.exports = {
   NAME,
+  SLUG,
   shortHelp,
   AUTHOR,
   COMMANDS,

--- a/src/plugins/blueprintCronPlugin/main.js
+++ b/src/plugins/blueprintCronPlugin/main.js
@@ -11,12 +11,16 @@ const spikeKit = require("../../spikeKit.js");
 /**
  * Provides an Asynchronous alternative to setInverval().
  */
-const {AsyncInterval} = require("../../asyncInterval.js");
+const { AsyncInterval } = require("../../asyncInterval.js");
 
 /**
  * The display name of the plugin.
  */
 const NAME = "The Name";
+/**
+ * Slug used to programmatically refer to the plugin. Lowercase letters, numbers, and dashes only.
+ */
+const SLUG = "the-name";
 /**
  * The author(s) of this plugin.
  */
@@ -26,8 +30,6 @@ const AUTHOR = "Some Person";
  * Called to start tasks on an interval.
  * @param {Discord.Client} bot Instantiated Discord Bot object.
  */
-function startCron(bot){
+function startCron(bot) {}
 
-}
-
-module.exports = {NAME, AUTHOR, startCron};
+module.exports = { NAME, SLUG, AUTHOR, startCron };

--- a/src/plugins/blueprintPlugin/main.js
+++ b/src/plugins/blueprintPlugin/main.js
@@ -12,6 +12,10 @@ const spikeKit = require("../../spikeKit.js");
  */
 const NAME = "The Name";
 /**
+ * Slug used to programmatically refer to the plugin. Lowercase letters, numbers, and dashes only.
+ */
+const SLUG = "the-name";
+/**
  * The author(s) of this plugin.
  */
 const AUTHOR = "Some Person";
@@ -29,8 +33,8 @@ const COMMANDS = ["command1", "command2"];
  * @param {string} args The rest of the message.
  * @returns Help text to be sent back to the user.
  */
- function help(prefix, command, args) {
-  return "How to use the command with given args."
+function help(prefix, command, args) {
+  return "How to use the command with given args.";
 }
 
 /**
@@ -38,8 +42,8 @@ const COMMANDS = ["command1", "command2"];
  * @param {string} prefix The command prefix.
  * @returns Help text for the main help screen.
  */
- function shortHelp(prefix){
-  return `${prefix}proofofconcept - Just a proof of concept.`
+function shortHelp(prefix) {
+  return `${prefix}proofofconcept - Just a proof of concept.`;
 }
 
 /**
@@ -49,9 +53,7 @@ const COMMANDS = ["command1", "command2"];
  * @param {Discord.Client} bot The instantiated Discord Bot object.
  * @param {Discord.Message} message An object representing the message sent.
  */
-function processCommand(command, args, bot, message){
-
-}
+function processCommand(command, args, bot, message) {}
 
 /**
  * Handles reactions added/removed to embeds sent by this plugin. To receive anything in this function, plugins must...
@@ -65,25 +67,30 @@ function processCommand(command, args, bot, message){
  * @param {boolean} add True if reaction added, False if removed.
  * @param {Discord.Client} bot The instantiated Discord Bot object.
  */
-function processReaction(reaction, user, add, bot){
-  console.log(`${user.username} ${add ? "Added" : "Removed"} a reaction on ${reaction.message.author.username}'s message: :${reaction.emoji.name}:.`)
+function processReaction(reaction, user, add, bot) {
+  console.log(
+    `${user.username} ${add ? "Added" : "Removed"} a reaction on ${
+      reaction.message.author.username
+    }'s message: :${reaction.emoji.name}:.`
+  );
 }
 
 /**
  * Runs when the bot is first started if exported below.
  * @param {Discord.Client} bot The instantiated Discord Bot object.
  */
-function onBotStart(bot){
-  console.log(`${NAME} has started.`)
+function onBotStart(bot) {
+  console.log(`${NAME} has started.`);
 }
 
 module.exports = {
-                  NAME, 
-                  shortHelp, 
-                  AUTHOR, 
-                  COMMANDS, 
-                  help, 
-                  processCommand,
-                  // processReaction,
-                  // onBotStart,
-                };
+  NAME,
+  SLUG,
+  shortHelp,
+  AUTHOR,
+  COMMANDS,
+  help,
+  processCommand,
+  // processReaction,
+  // onBotStart,
+};

--- a/src/plugins/challenges/main.js
+++ b/src/plugins/challenges/main.js
@@ -7,6 +7,7 @@ const fs = require("fs");
 const { throwErr } = require("../../botErr.js");
 
 const NAME = "Programming Challenges";
+const SLUG = "programming-challenges";
 const AUTHOR = "Brandon Ingli and Joshua Maxwell";
 const COMMANDS = ["challenges", "submitcode"];
 const FILENAME = "plugins/challenges/challenges.json";
@@ -263,6 +264,7 @@ function onBotStart(bot) {
 
 module.exports = {
   NAME,
+  SLUG,
   shortHelp,
   AUTHOR,
   COMMANDS,

--- a/src/plugins/core/main.js
+++ b/src/plugins/core/main.js
@@ -9,6 +9,7 @@ const { getLastCommit } = require("git-last-commit");
 const { throwErr } = require("../../botErr.js");
 
 const NAME = "Core";
+const SLUG = "core";
 const AUTHOR = "Joshua Maxwell and Brandon Ingli";
 const COMMANDS = [
   "remindme",
@@ -289,4 +290,12 @@ function processCommand(command, args, bot, message) {
   else if (command === "wiki") wiki(message);
 }
 
-module.exports = { NAME, shortHelp, AUTHOR, COMMANDS, help, processCommand };
+module.exports = {
+  NAME,
+  SLUG,
+  shortHelp,
+  AUTHOR,
+  COMMANDS,
+  help,
+  processCommand,
+};

--- a/src/plugins/enigma/main.js
+++ b/src/plugins/enigma/main.js
@@ -7,12 +7,16 @@
  */
 const spikeKit = require("../../spikeKit.js");
 
-const {enigma} = require("./enigma.js");
+const { enigma } = require("./enigma.js");
 
 /**
  * The display name of the plugin.
  */
 const NAME = "Enigma Machine";
+/**
+ * Slug used to programmatically refer to the plugin. Lowercase letters, numbers, and dashes only.
+ */
+const SLUG = "enigma";
 /**
  * The author(s) of this plugin.
  */
@@ -31,8 +35,8 @@ const COMMANDS = ["enigma"];
  * @param {string} args The rest of the message.
  * @returns Help text to be sent back to the user.
  */
- function help(prefix, command, args) {
-  if (command == "enigma"){
+function help(prefix, command, args) {
+  if (command == "enigma") {
     return `${prefix}enigma [message] [r1] [r1o] [r2] [r2o] [r3] [r3o] [ref]\nEncode or decode a message using Spike's enigma machine.
 message - String to encode/decode
 r1 - Name of rotor to use in rightmost position
@@ -61,8 +65,8 @@ Special thanks to Brandon Ingli for creating this enigma machine!`;
  * @param {string} prefix The command prefix.
  * @returns Help text for the main help screen.
  */
- function shortHelp(prefix){
-  return `${prefix}enigma - encode/decode a message.`
+function shortHelp(prefix) {
+  return `${prefix}enigma - encode/decode a message.`;
 }
 
 /**
@@ -72,19 +76,19 @@ Special thanks to Brandon Ingli for creating this enigma machine!`;
  * @param {Discord.Client} bot The instantiated Discord Bot object.
  * @param {Discord.Message} message An object representing the message sent.
  */
-function processCommand(command, args, bot, message){
-  if (command == "enigma"){
-    let enigmaArgs = args.split(' ');
+function processCommand(command, args, bot, message) {
+  if (command == "enigma") {
+    let enigmaArgs = args.split(" ");
     const str = enigmaArgs[0];
     let enigmaText;
     try {
-      if(enigmaArgs.length) {
+      if (enigmaArgs.length) {
         enigmaArgs.shift();
         enigmaText = enigma(str, ...enigmaArgs);
       } else {
         enigmaText = enigma(str);
       }
-    } catch (e){
+    } catch (e) {
       enigmaText = `Error: ${e}`;
     }
     spikeKit.reply(
@@ -101,4 +105,12 @@ function processCommand(command, args, bot, message){
   }
 }
 
-module.exports = {NAME, shortHelp, AUTHOR, COMMANDS, help, processCommand};
+module.exports = {
+  NAME,
+  SLUG,
+  shortHelp,
+  AUTHOR,
+  COMMANDS,
+  help,
+  processCommand,
+};

--- a/src/plugins/gamble/main.js
+++ b/src/plugins/gamble/main.js
@@ -8,13 +8,17 @@
  * A one stop shop for all things a Spike Plugin could need!
  */
 const spikeKit = require("../../spikeKit.js");
-const {getStudent, addBucks, getDat, getConsts} = require('../../faccess.js');
-const {throwErr} = require('../../botErr.js');
+const { getStudent, addBucks, getDat, getConsts } = require("../../faccess.js");
+const { throwErr } = require("../../botErr.js");
 
 /**
  * The display name of the plugin.
  */
 const NAME = "Gamble";
+/**
+ * Slug used to programmatically refer to the plugin. Lowercase letters, numbers, and dashes only.
+ */
+const SLUG = "gamble";
 /**
  * The author(s) of this plugin.
  */
@@ -33,8 +37,8 @@ const COMMANDS = ["wallet", "cointoss", "gift", "leaderboard", "dice", "slots"];
  * @param {string} args The rest of the message.
  * @returns Help text to be sent back to the user.
  */
- function help(prefix, command, args) {
-  switch(command){
+function help(prefix, command, args) {
+  switch (command) {
     case "wallet":
       return `${prefix}wallet [user]\nWith this command you can check the the amount of Spike Bucks in anyone's wallet. If you want to know how many Bucks you have in your own wallet, you can simply leave the user field blank.`;
     case "cointoss":
@@ -55,14 +59,14 @@ const COMMANDS = ["wallet", "cointoss", "gift", "leaderboard", "dice", "slots"];
  * @param {string} prefix The command prefix.
  * @returns Help text for the main help screen.
  */
- function shortHelp(prefix){
+function shortHelp(prefix) {
   return `Earn Spike Bucks to gamble or gift by sending messages.
 ${prefix}wallet - View Spike Bucks balance.
 ${prefix}cointoss - Wager Spike Bucks on Heads or Tails.
 ${prefix}gift - Gift some Spike Bucks to friends.
 ${prefix}leaderboard - View the leaderboard.
 ${prefix}dice - Wager Spike Bucks on a roll of the dice.
-${prefix}slots - Pull the handle and find a jackpot.`
+${prefix}slots - Pull the handle and find a jackpot.`;
 }
 
 /**
@@ -71,68 +75,62 @@ ${prefix}slots - Pull the handle and find a jackpot.`
  * @param {Integer} wager the amount of Spike Bucks being wagered
  * @returns whether or not the given wager is valid
  */
- const validWager = (msg, wager) => {
+const validWager = (msg, wager) => {
   // wager will be passed in as a string
   const temp = parseInt(wager);
   if (temp && temp >= 0 && getStudent(msg.author.id).wallet >= temp)
     return true;
 
-  throwErr(msg, 'wager');
+  throwErr(msg, "wager");
   return false;
-}
+};
 
 /**
  * Takes a user mention and turns it into their user id
  * @param {string} tag the tag/mentioned user
  * @returns the user's id
  */
-const detag = (tag) => tag.replace("<@!", "")
-                          .replace("<@", "")
-                          .replace(">", "");
+const detag = (tag) =>
+  tag.replace("<@!", "").replace("<@", "").replace(">", "");
 
 /**
  * Takes a \n separated string and turns it into a table
- * 
+ *
  * I would like to eventually make this function so that it can make tables
  * with a variable number of columns
- * @param {string} text 
+ * @param {string} text
  * @returns a table containing the given information
  */
 const tablify = (text) => {
-  const lines = text.split('\n');
+  const lines = text.split("\n");
 
   // gets length of longest line
   let maxLength = 0;
-  lines.forEach(t => {if(t.length > maxLength) maxLength = t.length});
+  lines.forEach((t) => {
+    if (t.length > maxLength) maxLength = t.length;
+  });
   maxLength += 4; // lil more room
 
   // top of table
-  let result = '\n╔';
-  for (let i = 0; i < maxLength; ++i)
-    result += '═';
+  let result = "\n╔";
+  for (let i = 0; i < maxLength; ++i) result += "═";
   result += "╗\n";
 
   // adds content
-  lines.forEach(t => {
+  lines.forEach((t) => {
     result += `║ ${t}`;
-    for (let i = 0; i < maxLength - t.length - 1; ++i)
-      result += ' ';
-    result += '║\n';
+    for (let i = 0; i < maxLength - t.length - 1; ++i) result += " ";
+    result += "║\n";
 
-    if (t !== lines[lines.length - 1])
-      result += '╠';
-    else
-      result += '╚'
-    for (let i = 0; i < maxLength; ++i)
-      result += '═';
-    if (t !== lines[lines.length - 1])
-      result += '╣\n'
-    else
-      result += '╝\n';
+    if (t !== lines[lines.length - 1]) result += "╠";
+    else result += "╚";
+    for (let i = 0; i < maxLength; ++i) result += "═";
+    if (t !== lines[lines.length - 1]) result += "╣\n";
+    else result += "╝\n";
   });
 
   return result;
-}
+};
 
 /**
  * gets the amount of Spike Bucks in a given user's wallet
@@ -140,12 +138,11 @@ const tablify = (text) => {
  * @param {string} id the id related to the wallet we want to find
  */
 const getWallet = (msg, id) => {
-  if (id === null)
-    id = msg.author.id;
+  if (id === null) id = msg.author.id;
 
   student = getStudent(id);
   if (!student) {
-    throwErr(msg, 'user');
+    throwErr(msg, "user");
     return;
   }
 
@@ -156,11 +153,12 @@ const getWallet = (msg, id) => {
       title,
       content,
       true,
-      msg.author.username, msg.author.avatarURL()
+      msg.author.username,
+      msg.author.avatarURL()
     ),
     msg
   );
-}
+};
 
 /**
  * Performs the cointoss gambling game
@@ -168,15 +166,17 @@ const getWallet = (msg, id) => {
  */
 const coinToss = (msg, prefix) => {
   // $cointoss [wager] [face]
-  const args = msg.content.split(' ');
-  
+  const args = msg.content.split(" ");
+
   // is it a valid wager?
-  if(!validWager(msg, args[1]))
-    return;
+  if (!validWager(msg, args[1])) return;
 
   // is it a valid coin face?
-  if (args.length != 3 || (args[2].toLowerCase() !== 'heads' && args[2].toLowerCase() !== 'tails')) {
-    throwErr(msg, 'syntax');
+  if (
+    args.length != 3 ||
+    (args[2].toLowerCase() !== "heads" && args[2].toLowerCase() !== "tails")
+  ) {
+    throwErr(msg, "syntax");
     return;
   }
 
@@ -184,33 +184,36 @@ const coinToss = (msg, prefix) => {
   const wager = parseInt(args[1]);
   addBucks(msg.author.id, -wager);
 
-  const coinState = Math.floor((Math.random() * 100) + 1) > 51;
+  const coinState = Math.floor(Math.random() * 100 + 1) > 51;
   const face = args[2];
-  let outcome = !coinState && face.toLowerCase() === 'heads' 
-              ? 'tails'
-              : !coinState && face.toLowerCase() === 'tails'
-              ? 'heads'
-              : face;
+  let outcome =
+    !coinState && face.toLowerCase() === "heads"
+      ? "tails"
+      : !coinState && face.toLowerCase() === "tails"
+      ? "heads"
+      : face;
 
-  const earnings = coinState ? Math.ceil(wager + (wager * 2.2)) : 0;
+  const earnings = coinState ? Math.ceil(wager + wager * 2.2) : 0;
   addBucks(msg.author, earnings);
 
-  const contents =  `${getConsts().gamble['coinImage']}` + 
-                    `Called: ${face.toUpperCase()}\n` +
-                    `Results: ${outcome.toUpperCase()}\n` +
-                    `Earnings: ${(earnings - wager)}`;
+  const contents =
+    `${getConsts().gamble["coinImage"]}` +
+    `Called: ${face.toUpperCase()}\n` +
+    `Results: ${outcome.toUpperCase()}\n` +
+    `Earnings: ${earnings - wager}`;
 
-  const title = 'Coin Toss';
+  const title = "Coin Toss";
   spikeKit.reply(
     spikeKit.createEmbed(
       title,
       contents,
       true,
-      msg.author.username, msg.author.avatarURL()
+      msg.author.username,
+      msg.author.avatarURL()
     ),
     msg
   );
-}
+};
 
 /**
  * Takes money from the caller and gifts it to a given user
@@ -218,41 +221,43 @@ const coinToss = (msg, prefix) => {
  */
 const gift = (msg) => {
   // gift [amt] [user]
-  const args = msg.content.split(' ');
+  const args = msg.content.split(" ");
   console.log(args);
 
   if (args.length != 3) {
-    throwErr(msg, 'syntax');
+    throwErr(msg, "syntax");
     return;
   }
 
   const giftAmt = parseInt(args[1]);
-  if (!validWager(msg, giftAmt)){
+  if (!validWager(msg, giftAmt)) {
     return;
   }
-  
+
   const recipient = getStudent(detag(args[2]));
   if (!recipient) {
-    throwErr(msg, 'user');
+    throwErr(msg, "user");
     return;
   }
 
   addBucks(msg.author, -giftAmt);
-  getDat()[detag(args[2])]['wallet'] += giftAmt;
-  const contents =  `${getConsts().gamble['giftImage']}` +
-                    `Amount: $${giftAmt}\n` +
-                    `To: ${recipient.name}\n` +
-                    `From: ${msg.author.username}`;
+  getDat()[detag(args[2])]["wallet"] += giftAmt;
+  const contents =
+    `${getConsts().gamble["giftImage"]}` +
+    `Amount: $${giftAmt}\n` +
+    `To: ${recipient.name}\n` +
+    `From: ${msg.author.username}`;
   spikeKit.reply(
     spikeKit.createEmbed(
       "Gift",
       contents,
       true,
-      msg.author.username, msg.author.avatarURL()
+      msg.author.username,
+      msg.author.avatarURL()
     ),
     msg
   );
-}
+};
 
 /**
  * Displays the leaderboard and those with the fattest wallets
@@ -261,87 +266,93 @@ const gift = (msg) => {
 const leaderboard = (msg) => {
   const keys = Object.keys(getDat());
   let users = [];
-  keys.forEach(t => users.push(getDat()[t]));
+  keys.forEach((t) => users.push(getDat()[t]));
   users.sort((a, b) => b.wallet - a.wallet);
 
-  let result = '';
+  let result = "";
   for (let i = 0; i < 10; ++i)
     result += `${i + 1} | ${users[i].name} - ${users[i].wallet}\n`;
   result = result.slice(0, result.length - 1);
-  const title = 'Coin Toss';
+  const title = "Coin Toss";
   spikeKit.reply(
     spikeKit.createEmbed(
       "Leaderboard",
       tablify(result),
       true,
-      msg.author.username, msg.author.avatarURL()
+      msg.author.username,
+      msg.author.avatarURL()
     ),
     msg
   );
-}
+};
 
 const stitch = (a, b) => {
-  const t1 = a.split('\n');
-  const t2 = b.split('\n');
-  let result = '';
-  for (let i = 0; i < t1.length; ++i)
-    result += `${t1[i]}${t2[i]}\n`;
+  const t1 = a.split("\n");
+  const t2 = b.split("\n");
+  let result = "";
+  for (let i = 0; i < t1.length; ++i) result += `${t1[i]}${t2[i]}\n`;
   return result;
-}
+};
 
 /**
  * plays a game of dice
  * @param {Message} msg the message sent by the user
  */
 const dice = (msg) => {
-  const wager = parseInt(msg.content.split(' ')[1]);
-  if (!validWager(msg, wager))
-    return;
+  const wager = parseInt(msg.content.split(" ")[1]);
+  if (!validWager(msg, wager)) return;
 
   addBucks(msg.author, -wager);
 
-  const die1 = Math.floor((Math.random() * 6) + 1);
-  const die2 = Math.floor((Math.random() * 6) + 1);
+  const die1 = Math.floor(Math.random() * 6 + 1);
+  const die2 = Math.floor(Math.random() * 6 + 1);
 
   console.log(`${die1}, ${die2}`);
 
-  const winnings = die1 === die2 && die1 === 6
-                 ? wager * 6
-                 : die1 === die2
-                 ? Math.ceil(wager * 3.5)
-                 : die1 + die2 > 7
-                 ? Math.ceil(wager * 2.7)
-                 : 0;
+  const winnings =
+    die1 === die2 && die1 === 6
+      ? wager * 6
+      : die1 === die2
+      ? Math.ceil(wager * 3.5)
+      : die1 + die2 > 7
+      ? Math.ceil(wager * 2.7)
+      : 0;
 
   addBucks(msg.author, winnings);
 
-  const img = //long boi
-  `${stitch(getConsts().gamble[`d${die1}0`], getConsts().gamble[`d0${die2}`])}`
-  
-  const content = `${img}Die 1: ${die1}\nDie 2: ${die2}\nEarnings: ${winnings - wager}`;
+  const img =
+    //long boi
+    `${stitch(
+      getConsts().gamble[`d${die1}0`],
+      getConsts().gamble[`d0${die2}`]
+    )}`;
+
+  const content = `${img}Die 1: ${die1}\nDie 2: ${die2}\nEarnings: ${
+    winnings - wager
+  }`;
   spikeKit.reply(
     spikeKit.createEmbed(
       "Dice Roll",
       content,
       true,
-      msg.author.username, msg.author.avatarURL()
+      msg.author.username,
+      msg.author.avatarURL()
     ),
     msg
   );
-}
+};
 
 /**
  * plays a game of slots
  * @param {Message} msg the message sent by the user
  */
 const slots = (msg) => {
-  if (!msg.member.roles.cache.has(getConsts().role["slots"])){
-    throwErr(msg, 'invalidPermsErr');
+  if (!msg.member.roles.cache.has(getConsts().role["slots"])) {
+    throwErr(msg, "invalidPermsErr");
     return;
   }
-  const wager = parseInt(msg.content.split(' ')[1]);
-  if (!validWager(msg, wager))
-    return;
+  const wager = parseInt(msg.content.split(" ")[1]);
+  if (!validWager(msg, wager)) return;
 
   addBucks(msg.author, -wager);
 
@@ -353,34 +364,34 @@ const slots = (msg) => {
   }
 
   let counts = [];
-  result.forEach(t => {
+  result.forEach((t) => {
     counts.push(
-      result.join('').split(new RegExp(t === '$' ? '\\$' : t, "gi")).length - 1
+      result.join("").split(new RegExp(t === "$" ? "\\$" : t, "gi")).length - 1
     );
   });
 
   let earnings = 0;
   const max = Math.max(...counts);
-  if (max === 2)
-    earnings = 2.5;
-  else if (max === 3)
-    earnings = 6;
-  else if (max === 4)
-    earnings = 16;
-  
-  earnings += 2 * (result.join('')
-                         .split(new RegExp( '\\$', "gi" ))
-                         .length - 1);
+  if (max === 2) earnings = 2.5;
+  else if (max === 3) earnings = 6;
+  else if (max === 4) earnings = 16;
+
+  earnings += 2 * (result.join("").split(new RegExp("\\$", "gi")).length - 1);
 
   earnings *= wager;
 
-  if (result[0] == '$' && result[1] == '$'
-    && result[2] == '$' && result[3] == '$')
+  if (
+    result[0] == "$" &&
+    result[1] == "$" &&
+    result[2] == "$" &&
+    result[3] == "$"
+  )
     earnings = wager * 151;
 
   addBucks(msg.author, earnings);
-  let contents = getConsts().gamble['slotsImage'].replace(
-    '#', `${result[0]} ${result[1]} ${result[2]} ${result[3]}`
+  let contents = getConsts().gamble["slotsImage"].replace(
+    "#",
+    `${result[0]} ${result[1]} ${result[2]} ${result[3]}`
   );
   contents += `Wager: ${wager}\nEarnings: ${earnings}`;
   spikeKit.reply(
@@ -388,11 +399,12 @@ const slots = (msg) => {
       "Slots",
       contents,
       true,
-      msg.author.username, msg.author.avatarURL()
+      msg.author.username,
+      msg.author.avatarURL()
     ),
     msg
   );
-}
+};
 
 /**
  * Handles incoming commands for this plugin.
@@ -401,24 +413,32 @@ const slots = (msg) => {
  * @param {Discord.Client} bot The instantiated Discord Bot object.
  * @param {Discord.Message} message An object representing the message sent.
  */
-function processCommand(command, args, bot, message){
-  if (command === 'wallet') {
+function processCommand(command, args, bot, message) {
+  if (command === "wallet") {
     if (args) {
       getWallet(message, detag(args));
     } else {
       getWallet(message, null);
     }
-  } else if (command === 'cointoss'){
+  } else if (command === "cointoss") {
     coinToss(message);
-  } else if (command === 'gift'){
+  } else if (command === "gift") {
     gift(message);
-  } else if (command === 'leaderboard'){
+  } else if (command === "leaderboard") {
     leaderboard(message);
-  } else if (command === 'dice'){
+  } else if (command === "dice") {
     dice(message);
-  } else if (command === 'slots'){
+  } else if (command === "slots") {
     slots(message);
   }
 }
 
-module.exports = {NAME, shortHelp, AUTHOR, COMMANDS, help, processCommand};
+module.exports = {
+  NAME,
+  SLUG,
+  shortHelp,
+  AUTHOR,
+  COMMANDS,
+  help,
+  processCommand,
+};

--- a/src/plugins/itsServiceNotes/main.js
+++ b/src/plugins/itsServiceNotes/main.js
@@ -18,6 +18,10 @@ const its = require("./truman-its-service-notes.js");
  */
 const NAME = "ITS Service Notes";
 /**
+ * Slug used to programmatically refer to the plugin. Lowercase letters, numbers, and dashes only.
+ */
+ const SLUG = "its-service-notes";
+/**
  * The author(s) of this plugin.
  */
 const AUTHOR = "Brandon Ingli";
@@ -46,4 +50,4 @@ function startCron(bot){
   asyncInterval.start();
 }
 
-module.exports = {NAME, AUTHOR, startCron};
+module.exports = {NAME, SLUG, AUTHOR, startCron};

--- a/src/plugins/shop/main.js
+++ b/src/plugins/shop/main.js
@@ -16,6 +16,10 @@ const { getStudent, addBucks, getConsts } = require("../../faccess.js");
  */
 const NAME = "Spike Store";
 /**
+ * Slug used to programmatically refer to the plugin. Lowercase letters, numbers, and dashes only.
+ */
+const SLUG = "spike-store";
+/**
  * The author(s) of this plugin.
  */
 const AUTHOR = "Joshua Maxwell and Brandon Ingli";
@@ -196,4 +200,12 @@ function processCommand(command, args, bot, message) {
   }
 }
 
-module.exports = { NAME, shortHelp, AUTHOR, COMMANDS, help, processCommand };
+module.exports = {
+  NAME,
+  SLUG,
+  shortHelp,
+  AUTHOR,
+  COMMANDS,
+  help,
+  processCommand,
+};

--- a/src/plugins/spike-lisp/main.js
+++ b/src/plugins/spike-lisp/main.js
@@ -3,132 +3,143 @@
  */
 const spikeKit = require("../../spikeKit.js");
 const spikeLisp = require("./interpreter.js").littleLisp;
-fs = require('fs');
-const FILENAME = 'plugins/spike-lisp/mount.json';
+fs = require("fs");
+const FILENAME = "plugins/spike-lisp/mount.json";
 
 const NAME = "Lisp Interpreter";
+const SLUG = "spike-lisp";
 const AUTHOR = "Joshua Maxwell and maryrosecook";
 const COMMANDS = ["exec", "mount", "call"];
 
- function help(prefix, command, args) {
-  return `${prefix}exec [code]\n`
-       + 'Spike-lisp is a simplified version of lisp created specifically '
-       + 'for this server. In order to execute your code, you will need to '
-       + `format your message as follows, replacing {bt} with a backtick.\n\n`
-       + `${prefix}exec\n`
-       + '{bt}{bt}{bt}lisp\n'
-       + '(print(4, (1, 2, 3)));\n'
-       + '{bt}{bt}{bt}';
+function help(prefix, command, args) {
+  return (
+    `${prefix}exec [code]\n` +
+    "Spike-lisp is a simplified version of lisp created specifically " +
+    "for this server. In order to execute your code, you will need to " +
+    `format your message as follows, replacing {bt} with a backtick.\n\n` +
+    `${prefix}exec\n` +
+    "{bt}{bt}{bt}lisp\n" +
+    "(print(4, (1, 2, 3)));\n" +
+    "{bt}{bt}{bt}"
+  );
 }
 
- function shortHelp(prefix){
-  return `${prefix}exec - Execute Spike-lisp code.`
+function shortHelp(prefix) {
+  return `${prefix}exec - Execute Spike-lisp code.`;
 }
 
 function mount(args, message) {
-  let dat = fs.readFileSync(FILENAME, {encoding: 'utf8', flag:'r'});
+  let dat = fs.readFileSync(FILENAME, { encoding: "utf8", flag: "r" });
   dat = JSON.parse(dat);
 
-  if (dat[args.split(' ')[0]]) {
+  if (dat[args.split(" ")[0]]) {
     spikeKit.reply(
       spikeKit.createEmbed(
         "Spike Lisp: ERROR",
-        `Program ${dat[args.split(' ')[0]]} already mounted`,
+        `Program ${dat[args.split(" ")[0]]} already mounted`,
         false,
         message.author.username,
         message.author.avatarURL()
-        ),
-      message);
+      ),
+      message
+    );
     return;
   }
 
-  dat[args.split('\n')[0]] = args.slice(args.indexOf('\n'));
+  dat[args.split("\n")[0]] = args.slice(args.indexOf("\n"));
 
   fs.writeFile(FILENAME, JSON.stringify(dat), (err, t) => {
-    if (err)
-      return console.log(err);
+    if (err) return console.log(err);
     console.log(`${JSON.stringify(dat)} > ${FILENAME}`);
   });
 
   spikeKit.reply(
     spikeKit.createEmbed(
       "Spike Lisp: SUCCESS",
-      `Program ${args.split('\n')[0]} has been mounted`,
+      `Program ${args.split("\n")[0]} has been mounted`,
       false,
       message.author.username,
       message.author.avatarURL()
-      ),
-    message);
+    ),
+    message
+  );
 }
 
 function call(args, message) {
-  let dat = fs.readFileSync(FILENAME, {encoding: 'utf8', flag:'r'});
+  let dat = fs.readFileSync(FILENAME, { encoding: "utf8", flag: "r" });
   dat = JSON.parse(dat);
 
-  const content = dat[args.split(' ')[0]];
+  const content = dat[args.split(" ")[0]];
 
   if (!content) {
     spikeKit.reply(
       spikeKit.createEmbed(
         "Spike Lisp: ERROR",
-        `Program ${dat[args.split('\n')[0]]} has not been mounted`,
+        `Program ${dat[args.split("\n")[0]]} has not been mounted`,
         false,
         message.author.username,
         message.author.avatarURL()
-        ),
-      message);
+      ),
+      message
+    );
     return;
   }
 
-  interp(argify(content, args.slice(args.indexOf(' ')).split(/,\s+/)), message);
+  interp(argify(content, args.slice(args.indexOf(" ")).split(/,\s+/)), message);
 }
 
 function argify(content, args) {
   let result = content;
   for (let i = 0; i < args.length; ++i) {
-    if (result.includes(`$${i}`))
-      result = result.replaceAll(`$${i}`, args[i]);
+    if (result.includes(`$${i}`)) result = result.replaceAll(`$${i}`, args[i]);
   }
 
   return result;
 }
 
 function interp(args, message) {
-  const cmd = args.slice('\n```lisp\n'.length, args.lastIndexOf('```'));
+  const cmd = args.slice("\n```lisp\n".length, args.lastIndexOf("```"));
   try {
     const content = "" + spikeLisp.interpret(spikeLisp.parse(message, cmd));
     spikeKit.reply(
       spikeKit.createEmbed(
         "Spike Lisp",
-        content.length > 0 ? '```' + content + '```' : "",
+        content.length > 0 ? "```" + content + "```" : "",
         false,
         message.author.username,
         message.author.avatarURL()
-        ),
-      message);
+      ),
+      message
+    );
   } catch (e) {
     var caller_line = e.stack.split("\n")[4];
     var index = caller_line.indexOf("at ");
-    var clean = caller_line.slice(index+2, caller_line.length);
+    var clean = caller_line.slice(index + 2, caller_line.length);
     spikeKit.reply(
       spikeKit.createEmbed(
         "Spike Lisp: ERROR",
-        '```' + e + '```\n```' + clean + '```',
+        "```" + e + "```\n```" + clean + "```",
         false,
         message.author.username,
         message.author.avatarURL()
-        ),
-      message);
+      ),
+      message
+    );
   }
 }
 
 function processCommand(command, args, bot, message) {
-  if (command === 'exec')
-    interp(args, message);
-  else if (command === 'mount') 
-    mount(args, message);
-  else if (command === 'call') 
-    call(args, message);
+  if (command === "exec") interp(args, message);
+  else if (command === "mount") mount(args, message);
+  else if (command === "call") call(args, message);
 }
 
-module.exports = {NAME, shortHelp, AUTHOR, COMMANDS, help, processCommand};
+module.exports = {
+  NAME,
+  SLUG,
+  shortHelp,
+  AUTHOR,
+  COMMANDS,
+  help,
+  processCommand,
+};


### PR DESCRIPTION
<!-- Thanks for taking the time to work on a patch! Please fill in the following. -->
<!-- We'll be in touch if we need any other information. -->
<!-- Once submitted, follow this PR's progress on the project board. -->
<!-- Notes like this are comments and won't appear in the PR. -->

**Related bugs/feature requests**
<!-- e.g. Resolves #2 -->
<!-- New bullet point for each issue if there's more than one. -->
+ Resolves  #38 

**Describe the changes**
<!-- A clear, concise description of the changes. -->
Split help menu into one page per plugin. The main help now provides just a list of plugins and commands to reach the submenu for that plugin.

**Expected behavior**
<!-- A clear, concise description of what you expect to happen. -->

**Screenshots**
<!-- If applicable, add screenshots to help explain your fix. -->

**New npm dependencies**
<!-- If there are new npm dependencies, list them below with their versions -->
<!-- Make sure changes to package.json and package-lock.json are committed as well -->

**Testing Instructions**
<!-- Instructions to thoroughly test this patch. -->

- [ ] Verify every plugin now has a `SLUG`
- [ ] Verify that `%help` shows a list of plugins and their plugin help commands
- [ ] Verify that the plugin help commands show the short help as expected
- [ ] Verify that the command help pages still work

**Additional context**
<!-- Add any other context about the PR here. -->
