### PR TITLE
Upgrade discord.js to v13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.0.5",
       "license": "ISC",
       "dependencies": {
+        "@discordjs/builders": "^0.8.2",
         "@discordjs/rest": "^0.1.0-canary.0",
         "discord-api-types": "^0.24.0",
         "discord.js": "^13.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "2.0.5",
       "license": "ISC",
       "dependencies": {
+        "@discordjs/rest": "^0.1.0-canary.0",
+        "discord-api-types": "^0.24.0",
         "discord.js": "^13.3.1",
         "dotenv": "^8.2.0",
         "git-last-commit": "^1.0.0",
@@ -56,6 +58,51 @@
         "node": ">= 6"
       }
     },
+    "node_modules/@discordjs/rest": {
+      "version": "0.1.0-canary.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-0.1.0-canary.0.tgz",
+      "integrity": "sha512-d+s//ISYVV+e0w/926wMEeO7vju+Pn11x1JM4tcmVMCHSDgpi6pnFCNAXF1TEdnDcy7xf9tq5cf2pQkb/7ySTQ==",
+      "dependencies": {
+        "@discordjs/collection": "^0.1.6",
+        "@sapphire/async-queue": "^1.1.4",
+        "@sapphire/snowflake": "^1.3.5",
+        "abort-controller": "^3.0.0",
+        "discord-api-types": "^0.18.1",
+        "form-data": "^4.0.0",
+        "node-fetch": "^2.6.1",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@discordjs/rest/node_modules/@discordjs/collection": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.1.6.tgz",
+      "integrity": "sha512-utRNxnd9kSS2qhyivo9lMlt5qgAUasH2gb7BEOn6p0efFh24gjGomHzWKMAPn2hEReOPQZCJaRKoURwRotKucQ=="
+    },
+    "node_modules/@discordjs/rest/node_modules/discord-api-types": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.18.1.tgz",
+      "integrity": "sha512-hNC38R9ZF4uaujaZQtQfm5CdQO58uhdkoHQAVvMfIL0LgOSZeW575W8H6upngQOuoxWd8tiRII3LLJm9zuQKYg==",
+      "deprecated": "No longer supported. Install the latest release (0.20.2)",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@discordjs/rest/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/@sapphire/async-queue": {
       "version": "1.1.9",
       "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.1.9.tgz",
@@ -63,6 +110,16 @@
       "engines": {
         "node": ">=v14.0.0",
         "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@sapphire/snowflake": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-1.3.6.tgz",
+      "integrity": "sha512-QnzuLp+p9D7agynVub/zqlDVriDza9y3STArBhNiNBUgIX8+GL5FpQxstRfw1jDr5jkZUjcuKYAHxjIuXKdJAg==",
+      "deprecated": "This version has been automatically deprecated by @favware/npm-deprecate. Please use a newer version.",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
       }
     },
     "node_modules/@sindresorhus/is": {
@@ -96,6 +153,17 @@
       "integrity": "sha512-cyeefcUCgJlEk+hk2h3N+MqKKsPViQgF5boi9TTHSK+PoR9KWBb/C5ccPcDyAqgsbAYHTwulch725DV84+pSpg==",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
       }
     },
     "node_modules/asynckit": {
@@ -178,6 +246,14 @@
       "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/form-data": {
@@ -343,10 +419,52 @@
         "mime-types": "^2.1.12"
       }
     },
+    "@discordjs/rest": {
+      "version": "0.1.0-canary.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-0.1.0-canary.0.tgz",
+      "integrity": "sha512-d+s//ISYVV+e0w/926wMEeO7vju+Pn11x1JM4tcmVMCHSDgpi6pnFCNAXF1TEdnDcy7xf9tq5cf2pQkb/7ySTQ==",
+      "requires": {
+        "@discordjs/collection": "^0.1.6",
+        "@sapphire/async-queue": "^1.1.4",
+        "@sapphire/snowflake": "^1.3.5",
+        "abort-controller": "^3.0.0",
+        "discord-api-types": "^0.18.1",
+        "form-data": "^4.0.0",
+        "node-fetch": "^2.6.1",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@discordjs/collection": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.1.6.tgz",
+          "integrity": "sha512-utRNxnd9kSS2qhyivo9lMlt5qgAUasH2gb7BEOn6p0efFh24gjGomHzWKMAPn2hEReOPQZCJaRKoURwRotKucQ=="
+        },
+        "discord-api-types": {
+          "version": "0.18.1",
+          "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.18.1.tgz",
+          "integrity": "sha512-hNC38R9ZF4uaujaZQtQfm5CdQO58uhdkoHQAVvMfIL0LgOSZeW575W8H6upngQOuoxWd8tiRII3LLJm9zuQKYg=="
+        },
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
+    },
     "@sapphire/async-queue": {
       "version": "1.1.9",
       "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.1.9.tgz",
       "integrity": "sha512-CbXaGwwlEMq+l1TRu01FJCvySJ1CEFKFclHT48nIfNeZXaAAmmwwy7scUKmYHPUa3GhoMp6Qr1B3eAJux6XgOQ=="
+    },
+    "@sapphire/snowflake": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-1.3.6.tgz",
+      "integrity": "sha512-QnzuLp+p9D7agynVub/zqlDVriDza9y3STArBhNiNBUgIX8+GL5FpQxstRfw1jDr5jkZUjcuKYAHxjIuXKdJAg=="
     },
     "@sindresorhus/is": {
       "version": "4.2.0",
@@ -373,6 +491,14 @@
       "integrity": "sha512-cyeefcUCgJlEk+hk2h3N+MqKKsPViQgF5boi9TTHSK+PoR9KWBb/C5ccPcDyAqgsbAYHTwulch725DV84+pSpg==",
       "requires": {
         "@types/node": "*"
+      }
+    },
+    "abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "requires": {
+        "event-target-shim": "^5.0.0"
       }
     },
     "asynckit": {
@@ -431,6 +557,11 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
       "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g=="
+    },
+    "event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
     },
     "form-data": {
       "version": "3.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,19 +9,39 @@
       "version": "2.0.5",
       "license": "ISC",
       "dependencies": {
-        "discord.js": "^12.5.3",
+        "discord.js": "^13.3.1",
         "dotenv": "^8.2.0",
         "git-last-commit": "^1.0.0",
         "piston-client": "^1.0.2"
       },
       "engines": {
-        "node": ">=15.0.0"
+        "node": ">=16.6.0"
+      }
+    },
+    "node_modules/@discordjs/builders": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-0.8.2.tgz",
+      "integrity": "sha512-/YRd11SrcluqXkKppq/FAVzLIPRVlIVmc6X8ZklspzMIHDtJ+A4W37D43SHvLdH//+NnK+SHW/WeOF4Ts54PeQ==",
+      "dependencies": {
+        "@sindresorhus/is": "^4.2.0",
+        "discord-api-types": "^0.24.0",
+        "ow": "^0.27.0",
+        "ts-mixer": "^6.0.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/@discordjs/collection": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.1.6.tgz",
-      "integrity": "sha512-utRNxnd9kSS2qhyivo9lMlt5qgAUasH2gb7BEOn6p0efFh24gjGomHzWKMAPn2hEReOPQZCJaRKoURwRotKucQ=="
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.3.2.tgz",
+      "integrity": "sha512-dMjLl60b2DMqObbH1MQZKePgWhsNe49XkKBZ0W5Acl5uVV43SN414i2QfZwRI7dXAqIn8pEWD2+XXQFn9KWxqg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
     },
     "node_modules/@discordjs/form-data": {
       "version": "3.0.1",
@@ -36,21 +56,60 @@
         "node": ">= 6"
       }
     },
-    "node_modules/abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "dependencies": {
-        "event-target-shim": "^5.0.0"
-      },
+    "node_modules/@sapphire/async-queue": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.1.9.tgz",
+      "integrity": "sha512-CbXaGwwlEMq+l1TRu01FJCvySJ1CEFKFclHT48nIfNeZXaAAmmwwy7scUKmYHPUa3GhoMp6Qr1B3eAJux6XgOQ==",
       "engines": {
-        "node": ">=6.5"
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.2.0.tgz",
+      "integrity": "sha512-VkE3KLBmJwcCaVARtQpfuKcKv8gcBmUubrfHGF84dXuuW6jgsRYxPtzcIhPyK9WAPpRt2/xY6zkD9MnRaJzSyw==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "16.11.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.9.tgz",
+      "integrity": "sha512-MKmdASMf3LtPzwLyRrFjtFFZ48cMf8jmX5VRYrDQiJa8Ybu5VAmkqBWqKU8fdCwD8ysw4mQ9nrEHvzg6gunR7A=="
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.5.12",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.12.tgz",
+      "integrity": "sha512-MKgC4dlq4kKNa/mYrwpKfzQMB5X3ee5U6fSprkKpToBqBmX4nFZL9cW5jl6sWn+xpRJ7ypWh2yyqqr8UUCstSw==",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.2.0.tgz",
+      "integrity": "sha512-cyeefcUCgJlEk+hk2h3N+MqKKsPViQgF5boi9TTHSK+PoR9KWBb/C5ccPcDyAqgsbAYHTwulch725DV84+pSpg==",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -71,22 +130,46 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/discord-api-types": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.24.0.tgz",
+      "integrity": "sha512-X0uA2a92cRjowUEXpLZIHWl4jiX1NsUpDhcEOpa1/hpO1vkaokgZ8kkPtPih9hHth5UVQ3mHBu/PpB4qjyfJ4A==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/discord.js": {
-      "version": "12.5.3",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-12.5.3.tgz",
-      "integrity": "sha512-D3nkOa/pCkNyn6jLZnAiJApw2N9XrIsXUAdThf01i7yrEuqUmDGc7/CexVWwEcgbQR97XQ+mcnqJpmJ/92B4Aw==",
+      "version": "13.3.1",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-13.3.1.tgz",
+      "integrity": "sha512-zn4G8tL5+tMV00+0aSsVYNYcIfMSdT2g0nudKny+Ikd+XKv7m6bqI7n3Vji0GIRqXDr5ArPaw+iYFM2I1Iw3vg==",
       "dependencies": {
-        "@discordjs/collection": "^0.1.6",
+        "@discordjs/builders": "^0.8.1",
+        "@discordjs/collection": "^0.3.2",
         "@discordjs/form-data": "^3.0.1",
-        "abort-controller": "^3.0.0",
+        "@sapphire/async-queue": "^1.1.8",
+        "@types/node-fetch": "^2.5.12",
+        "@types/ws": "^8.2.0",
+        "discord-api-types": "^0.24.0",
         "node-fetch": "^2.6.1",
-        "prism-media": "^1.2.9",
-        "setimmediate": "^1.0.5",
-        "tweetnacl": "^1.0.3",
-        "ws": "^7.4.4"
+        "ws": "^8.2.3"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=16.6.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/dot-prop": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-6.0.1.tgz",
+      "integrity": "sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==",
+      "dependencies": {
+        "is-obj": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/dotenv": {
@@ -97,18 +180,36 @@
         "node": ">=10"
       }
     },
-    "node_modules/event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+    "node_modules/form-data": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
       "engines": {
-        "node": ">=6"
+        "node": ">= 6"
       }
     },
     "node_modules/git-last-commit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/git-last-commit/-/git-last-commit-1.0.0.tgz",
       "integrity": "sha512-wpnmsd2dW1MnoencljcWO/06VUealfMaY40ZjK5t3v9ljL+bKCMbNaTn/YzwIh4pDo2hk5QcN+pLzUJ8aWB17A=="
+    },
+    "node_modules/is-obj": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
     },
     "node_modules/mime-db": {
       "version": "1.47.0",
@@ -137,6 +238,25 @@
         "node": "4.x || >=6.0.0"
       }
     },
+    "node_modules/ow": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/ow/-/ow-0.27.0.tgz",
+      "integrity": "sha512-SGnrGUbhn4VaUGdU0EJLMwZWSupPmF46hnTRII7aCLCrqixTAC5eKo8kI4/XXf1eaaI8YEVT+3FeGNJI9himAQ==",
+      "dependencies": {
+        "@sindresorhus/is": "^4.0.1",
+        "callsites": "^3.1.0",
+        "dot-prop": "^6.0.1",
+        "lodash.isequal": "^4.5.0",
+        "type-fest": "^1.2.1",
+        "vali-date": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/piston-client": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/piston-client/-/piston-client-1.0.2.tgz",
@@ -145,47 +265,41 @@
         "node-fetch": "^2.6.1"
       }
     },
-    "node_modules/prism-media": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/prism-media/-/prism-media-1.2.9.tgz",
-      "integrity": "sha512-UHCYuqHipbTR1ZsXr5eg4JUmHER8Ss4YEb9Azn+9zzJ7/jlTtD1h0lc4g6tNx3eMlB8Mp6bfll0LPMAV4R6r3Q==",
-      "peerDependencies": {
-        "@discordjs/opus": "^0.5.0",
-        "ffmpeg-static": "^4.2.7 || ^3.0.0 || ^2.4.0",
-        "node-opus": "^0.3.3",
-        "opusscript": "^0.0.8"
+    "node_modules/ts-mixer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.0.tgz",
+      "integrity": "sha512-nXIb1fvdY5CBSrDIblLn73NW0qRDk5yJ0Sk1qPBF560OdJfQp9jhl+0tzcY09OZ9U+6GpeoI9RjwoIKFIoB9MQ=="
+    },
+    "node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+    },
+    "node_modules/type-fest": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+      "engines": {
+        "node": ">=10"
       },
-      "peerDependenciesMeta": {
-        "@discordjs/opus": {
-          "optional": true
-        },
-        "ffmpeg-static": {
-          "optional": true
-        },
-        "node-opus": {
-          "optional": true
-        },
-        "opusscript": {
-          "optional": true
-        }
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/setimmediate": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
-    },
-    "node_modules/tweetnacl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
-      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
+    "node_modules/vali-date": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
+      "integrity": "sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/ws": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.0.tgz",
-      "integrity": "sha512-6ezXvzOZupqKj4jUqbQ9tXuJNo+BR2gU8fFRk3XCP3e0G6WT414u5ELe6Y0vtp7kmSJ3F7YWObSNr1ESsgi4vw==",
+      "version": "8.2.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
+      "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
       "engines": {
-        "node": ">=8.3.0"
+        "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
@@ -202,10 +316,22 @@
     }
   },
   "dependencies": {
+    "@discordjs/builders": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-0.8.2.tgz",
+      "integrity": "sha512-/YRd11SrcluqXkKppq/FAVzLIPRVlIVmc6X8ZklspzMIHDtJ+A4W37D43SHvLdH//+NnK+SHW/WeOF4Ts54PeQ==",
+      "requires": {
+        "@sindresorhus/is": "^4.2.0",
+        "discord-api-types": "^0.24.0",
+        "ow": "^0.27.0",
+        "ts-mixer": "^6.0.0",
+        "tslib": "^2.3.1"
+      }
+    },
     "@discordjs/collection": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.1.6.tgz",
-      "integrity": "sha512-utRNxnd9kSS2qhyivo9lMlt5qgAUasH2gb7BEOn6p0efFh24gjGomHzWKMAPn2hEReOPQZCJaRKoURwRotKucQ=="
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.3.2.tgz",
+      "integrity": "sha512-dMjLl60b2DMqObbH1MQZKePgWhsNe49XkKBZ0W5Acl5uVV43SN414i2QfZwRI7dXAqIn8pEWD2+XXQFn9KWxqg=="
     },
     "@discordjs/form-data": {
       "version": "3.0.1",
@@ -217,18 +343,47 @@
         "mime-types": "^2.1.12"
       }
     },
-    "abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+    "@sapphire/async-queue": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.1.9.tgz",
+      "integrity": "sha512-CbXaGwwlEMq+l1TRu01FJCvySJ1CEFKFclHT48nIfNeZXaAAmmwwy7scUKmYHPUa3GhoMp6Qr1B3eAJux6XgOQ=="
+    },
+    "@sindresorhus/is": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.2.0.tgz",
+      "integrity": "sha512-VkE3KLBmJwcCaVARtQpfuKcKv8gcBmUubrfHGF84dXuuW6jgsRYxPtzcIhPyK9WAPpRt2/xY6zkD9MnRaJzSyw=="
+    },
+    "@types/node": {
+      "version": "16.11.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.9.tgz",
+      "integrity": "sha512-MKmdASMf3LtPzwLyRrFjtFFZ48cMf8jmX5VRYrDQiJa8Ybu5VAmkqBWqKU8fdCwD8ysw4mQ9nrEHvzg6gunR7A=="
+    },
+    "@types/node-fetch": {
+      "version": "2.5.12",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.12.tgz",
+      "integrity": "sha512-MKgC4dlq4kKNa/mYrwpKfzQMB5X3ee5U6fSprkKpToBqBmX4nFZL9cW5jl6sWn+xpRJ7ypWh2yyqqr8UUCstSw==",
       "requires": {
-        "event-target-shim": "^5.0.0"
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      }
+    },
+    "@types/ws": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.2.0.tgz",
+      "integrity": "sha512-cyeefcUCgJlEk+hk2h3N+MqKKsPViQgF5boi9TTHSK+PoR9KWBb/C5ccPcDyAqgsbAYHTwulch725DV84+pSpg==",
+      "requires": {
+        "@types/node": "*"
       }
     },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -243,19 +398,33 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
+    "discord-api-types": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.24.0.tgz",
+      "integrity": "sha512-X0uA2a92cRjowUEXpLZIHWl4jiX1NsUpDhcEOpa1/hpO1vkaokgZ8kkPtPih9hHth5UVQ3mHBu/PpB4qjyfJ4A=="
+    },
     "discord.js": {
-      "version": "12.5.3",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-12.5.3.tgz",
-      "integrity": "sha512-D3nkOa/pCkNyn6jLZnAiJApw2N9XrIsXUAdThf01i7yrEuqUmDGc7/CexVWwEcgbQR97XQ+mcnqJpmJ/92B4Aw==",
+      "version": "13.3.1",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-13.3.1.tgz",
+      "integrity": "sha512-zn4G8tL5+tMV00+0aSsVYNYcIfMSdT2g0nudKny+Ikd+XKv7m6bqI7n3Vji0GIRqXDr5ArPaw+iYFM2I1Iw3vg==",
       "requires": {
-        "@discordjs/collection": "^0.1.6",
+        "@discordjs/builders": "^0.8.1",
+        "@discordjs/collection": "^0.3.2",
         "@discordjs/form-data": "^3.0.1",
-        "abort-controller": "^3.0.0",
+        "@sapphire/async-queue": "^1.1.8",
+        "@types/node-fetch": "^2.5.12",
+        "@types/ws": "^8.2.0",
+        "discord-api-types": "^0.24.0",
         "node-fetch": "^2.6.1",
-        "prism-media": "^1.2.9",
-        "setimmediate": "^1.0.5",
-        "tweetnacl": "^1.0.3",
-        "ws": "^7.4.4"
+        "ws": "^8.2.3"
+      }
+    },
+    "dot-prop": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-6.0.1.tgz",
+      "integrity": "sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==",
+      "requires": {
+        "is-obj": "^2.0.0"
       }
     },
     "dotenv": {
@@ -263,15 +432,30 @@
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
       "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g=="
     },
-    "event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
+    "form-data": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      }
     },
     "git-last-commit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/git-last-commit/-/git-last-commit-1.0.0.tgz",
       "integrity": "sha512-wpnmsd2dW1MnoencljcWO/06VUealfMaY40ZjK5t3v9ljL+bKCMbNaTn/YzwIh4pDo2hk5QcN+pLzUJ8aWB17A=="
+    },
+    "is-obj": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w=="
+    },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
     },
     "mime-db": {
       "version": "1.47.0",
@@ -291,6 +475,19 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
       "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
+    "ow": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/ow/-/ow-0.27.0.tgz",
+      "integrity": "sha512-SGnrGUbhn4VaUGdU0EJLMwZWSupPmF46hnTRII7aCLCrqixTAC5eKo8kI4/XXf1eaaI8YEVT+3FeGNJI9himAQ==",
+      "requires": {
+        "@sindresorhus/is": "^4.0.1",
+        "callsites": "^3.1.0",
+        "dot-prop": "^6.0.1",
+        "lodash.isequal": "^4.5.0",
+        "type-fest": "^1.2.1",
+        "vali-date": "^1.0.0"
+      }
+    },
     "piston-client": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/piston-client/-/piston-client-1.0.2.tgz",
@@ -299,26 +496,30 @@
         "node-fetch": "^2.6.1"
       }
     },
-    "prism-media": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/prism-media/-/prism-media-1.2.9.tgz",
-      "integrity": "sha512-UHCYuqHipbTR1ZsXr5eg4JUmHER8Ss4YEb9Azn+9zzJ7/jlTtD1h0lc4g6tNx3eMlB8Mp6bfll0LPMAV4R6r3Q==",
-      "requires": {}
+    "ts-mixer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.0.tgz",
+      "integrity": "sha512-nXIb1fvdY5CBSrDIblLn73NW0qRDk5yJ0Sk1qPBF560OdJfQp9jhl+0tzcY09OZ9U+6GpeoI9RjwoIKFIoB9MQ=="
     },
-    "setimmediate": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+    "tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
-    "tweetnacl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
-      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
+    "type-fest": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA=="
+    },
+    "vali-date": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
+      "integrity": "sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY="
     },
     "ws": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.0.tgz",
-      "integrity": "sha512-6ezXvzOZupqKj4jUqbQ9tXuJNo+BR2gU8fFRk3XCP3e0G6WT414u5ELe6Y0vtp7kmSJ3F7YWObSNr1ESsgi4vw==",
+      "version": "8.2.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
+      "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
       "requires": {}
     }
   }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@discordjs/builders": "^0.8.2",
     "@discordjs/rest": "^0.1.0-canary.0",
     "discord-api-types": "^0.24.0",
     "discord.js": "^13.3.1",

--- a/package.json
+++ b/package.json
@@ -21,13 +21,13 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "discord.js": "^12.5.3",
+    "discord.js": "^13.3.1",
     "dotenv": "^8.2.0",
     "git-last-commit": "^1.0.0",
     "piston-client": "^1.0.2"
   },
   "prettier": {},
   "engines": {
-    "node": ">=15.0.0"
+    "node": ">=16.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@discordjs/rest": "^0.1.0-canary.0",
+    "discord-api-types": "^0.24.0",
     "discord.js": "^13.3.1",
     "dotenv": "^8.2.0",
     "git-last-commit": "^1.0.0",

--- a/src/bot.js
+++ b/src/bot.js
@@ -22,6 +22,7 @@ readIn();
 // starting the bot
 const bot = new Client({
   intents: [
+    Intents.FLAGS.GUILDS,
     Intents.FLAGS.GUILD_MESSAGES,
     Intents.FLAGS.GUILD_MESSAGE_REACTIONS,
     Intents.FLAGS.DIRECT_MESSAGES,
@@ -41,10 +42,7 @@ bot.on("ready", async () => {
   slashCommands.setBot(bot);
 
   // Uncomment below to delete all commands
-  // const commands = await slashCommands.getCommands();
-  // for (command of commands){
-  // await slashCommands.deleteCommand(command.id);
-  // }
+  // slashCommands.deleteAllCommands();
 
   // Uncomment below to add new or update existing commands
   // slashCommands.addAllCommands();
@@ -52,7 +50,7 @@ bot.on("ready", async () => {
   onBotStart(bot);
 });
 // on message recieved
-bot.on("message", (message) => {
+bot.on("messageCreate", (message) => {
   if (
     message.member &&
     !message.member.roles.cache.has(getConsts().role["verified"]) &&

--- a/src/bot.js
+++ b/src/bot.js
@@ -7,7 +7,7 @@
 
 // dependencies
 require("dotenv").config();
-const { Client } = require("discord.js");
+const { Client, Intents } = require("discord.js");
 const { execute, onBotStart, onReaction } = require("./commands.js");
 const { readIn, addBucks, getConsts } = require("./faccess.js");
 const { verify } = require("./verify.js");
@@ -20,7 +20,14 @@ const PREFIX = "$";
 readIn();
 
 // starting the bot
-const bot = new Client();
+const bot = new Client({
+  intents: [
+    Intents.FLAGS.GUILD_MESSAGES,
+    Intents.FLAGS.GUILD_MESSAGE_REACTIONS,
+    Intents.FLAGS.DIRECT_MESSAGES,
+    Intents.FLAGS.DIRECT_MESSAGE_REACTIONS,
+  ],
+});
 
 const { spikeUID, simoneUID } = getConsts();
 

--- a/src/bot.js
+++ b/src/bot.js
@@ -42,10 +42,6 @@ bot.on("ready", async () => {
   // Uncomment below to add new or update existing commands
   // slashCommands.addAllCommands();
 
-  bot.ws.on("INTERACTION_CREATE", async (interaction) => {
-    slashCommands.handleInteraction(interaction, bot);
-  });
-
   onBotStart(bot);
 });
 // on message recieved
@@ -69,6 +65,12 @@ bot.on("message", (message) => {
 
   // if a user sends a message
   if (!message.author.bot) addBucks(message.author, 1);
+});
+
+// on Slash Commands
+bot.on("interactionCreate", async (interaction) => {
+  if (!interaction.isCommand()) return;
+  slashCommands.handleInteraction(interaction, bot);
 });
 
 // on Reactions

--- a/src/bot.js
+++ b/src/bot.js
@@ -28,6 +28,7 @@ const bot = new Client({
     Intents.FLAGS.DIRECT_MESSAGES,
     Intents.FLAGS.DIRECT_MESSAGE_REACTIONS,
   ],
+  partials: ["CHANNEL"],
 });
 
 const { spikeUID, simoneUID } = getConsts();
@@ -50,7 +51,11 @@ bot.on("ready", async () => {
   onBotStart(bot);
 });
 // on message recieved
-bot.on("messageCreate", (message) => {
+bot.on("messageCreate", async (message) => {
+  if (message.partial) {
+    message = await message.fetch();
+  }
+
   if (
     message.member &&
     !message.member.roles.cache.has(getConsts().role["verified"]) &&
@@ -59,7 +64,7 @@ bot.on("messageCreate", (message) => {
     verify(message, bot);
   }
 
-  if (message.channel.type === "dm") {
+  if (message.channel.type === "DM") {
     //TODO
   }
 

--- a/src/commands.js
+++ b/src/commands.js
@@ -12,7 +12,6 @@ const plugins = [
   require("./plugins/betting/main.js"),
   require("./plugins/shop/main.js"),
   require("./plugins/enigma/main.js"),
-  require("./plugins/spike-lisp/main.js"),
   require("./plugins/challenges/main.js"),
 ];
 

--- a/src/plugins/adminAnnounce/main.js
+++ b/src/plugins/adminAnnounce/main.js
@@ -50,7 +50,7 @@ function shortHelp(prefix) {
 function hasPermission(guild, id) {
   const member = guild.members.cache.get(id);
   return (
-    member.hasPermission("ADMINISTRATOR") ||
+    member.permissions.has("ADMINISTRATOR") ||
     member.roles.cache.has(getConsts().role.botexpert)
   );
 }

--- a/src/plugins/betting/main.js
+++ b/src/plugins/betting/main.js
@@ -390,7 +390,7 @@ Bet ${winningWager.bet}, Win ${winningsPerPerson}\nWinners: ${winnersNames.join(
     betAuthor.username,
     betAuthor.avatarURL()
   );
-  oldMessage.edit(oldMessageNewEmbed);
+  oldMessage.edit({ embeds: [oldMessageNewEmbed] });
 
   // Remove from the active bets
   delete bets[thisBetID];
@@ -453,7 +453,7 @@ function processReaction(reaction, user, add, bot) {
   const [thisBetID, thisBet] = thisBetReduced[0];
 
   // Verify that they can bet
-  if (thisBet.createdBy == user.id) {
+  if (thisBet.createdBy == user.id && add) {
     spikeKit.throwErr(reaction.message, "betOwnerBets");
     console.error(
       `Bet: ${user.username} tried to wager on their own bet ${thisBetID}`

--- a/src/plugins/betting/main.js
+++ b/src/plugins/betting/main.js
@@ -233,7 +233,7 @@ async function newBet(args, bot, message) {
     message.author.username,
     message.author.avatarURL()
   );
-  await spikeKit.reply(embed, message);
+  await spikeKit.send(embed, message.channelId, bot);
 
   const getLastMessage = await message.channel.messages.fetch({ limit: 1 });
   const lastMessage = getLastMessage.first();

--- a/src/plugins/betting/main.js
+++ b/src/plugins/betting/main.js
@@ -453,12 +453,14 @@ function processReaction(reaction, user, add, bot) {
   const [thisBetID, thisBet] = thisBetReduced[0];
 
   // Verify that they can bet
-  if (thisBet.createdBy == user.id && add) {
-    spikeKit.throwErr(reaction.message, "betOwnerBets");
-    console.error(
-      `Bet: ${user.username} tried to wager on their own bet ${thisBetID}`
-    );
-    reaction.users.remove(user.id);
+  if (thisBet.createdBy == user.id) {
+    if (add) {
+      spikeKit.throwErr(reaction.message, "betOwnerBets");
+      console.error(
+        `Bet: ${user.username} tried to wager on their own bet ${thisBetID}`
+      );
+      reaction.users.remove(user.id);
+    }
     return;
   }
 

--- a/src/plugins/challenges/main.js
+++ b/src/plugins/challenges/main.js
@@ -159,7 +159,7 @@ async function submitCode(args, bot, message) {
   );
 
   if (codeValidation.validated) {
-    spikeKit.reply(
+    spikeKit.send(
       spikeKit.createEmbed(
         `Programming Challenges: ${challenge.title}`,
         `Your submission passed validation! Congratulations!`,
@@ -167,7 +167,8 @@ async function submitCode(args, bot, message) {
         message.author.username,
         message.author.avatarURL()
       ),
-      message
+      message.channelId,
+      bot
     );
     challenges[segs[1]].passed.push({
       submittedBy: message.author.id,
@@ -176,7 +177,7 @@ async function submitCode(args, bot, message) {
     });
     writeChallenges(challenges);
   } else if (codeValidation.success) {
-    spikeKit.reply(
+    spikeKit.send(
       spikeKit.createEmbed(
         `Programming Challenges: ${challenge.title}`,
         `Your submission ran successfully, but produced incorrect output.`,
@@ -184,10 +185,11 @@ async function submitCode(args, bot, message) {
         message.author.username,
         message.author.avatarURL()
       ),
-      message
+      message.channelId,
+      bot
     );
   } else {
-    spikeKit.reply(
+    spikeKit.send(
       spikeKit.createEmbed(
         `Programming Challenges: ${challenge.title}`,
         `Your submission only produced error output:\n\`\`\`\n${codeValidation.output}\n\`\`\``,
@@ -195,7 +197,8 @@ async function submitCode(args, bot, message) {
         message.author.username,
         message.author.avatarURL()
       ),
-      message
+      message.channelId,
+      bot
     );
   }
 }

--- a/src/plugins/challenges/main.js
+++ b/src/plugins/challenges/main.js
@@ -122,7 +122,8 @@ async function submitCode(args, bot, message) {
   } catch (e) {
     spikeKit.reply(
       `${message.author}: I couldn't delete your message! Please delete it to shield your work from others!`,
-      message
+      message,
+      true
     );
   }
   // Check message format

--- a/src/plugins/core/main.js
+++ b/src/plugins/core/main.js
@@ -128,7 +128,7 @@ const embedify = (args, msg, bot) => {
 
 const clear = (msg) => {
   if (
-    !msg.member.hasPermission("ADMINISTRATOR") &&
+    !msg.member.permissions.has("ADMINISTRATOR") &&
     !msg.member.roles.cache.has(getConsts().role.botexpert)
   ) {
     spikeKit.throwErr(msg, "invalidPermsErr");

--- a/src/plugins/core/main.js
+++ b/src/plugins/core/main.js
@@ -77,7 +77,6 @@ const remindMe = (msg, args) => {
     parseInt(segs[3]) * spikeKit.SECOND;
 
   setTimeout((_) => {
-    spikeKit.reply(msg.author.toString(), msg);
     spikeKit.reply(
       spikeKit.createEmbed(
         "Reminder :bell:",
@@ -105,14 +104,14 @@ const remindMe = (msg, args) => {
   );
 };
 
-const embedify = (args, msg) => {
+const embedify = (args, msg, bot) => {
   const title = args.slice(0, args.indexOf(";"));
   const content = args
     .slice(args.indexOf(";") + 1)
     .trimStart()
     .trimEnd();
 
-  spikeKit.reply(
+  spikeKit.send(
     spikeKit.createEmbed(
       title,
       content,
@@ -120,7 +119,8 @@ const embedify = (args, msg) => {
       msg.author.username,
       msg.author.avatarURL()
     ),
-    msg
+    msg.channelId,
+    bot
   );
   msg.delete();
 };
@@ -147,12 +147,12 @@ const clear = (msg) => {
   msg.channel.bulkDelete(parseInt(arg));
 };
 
-const echo = (content, msg) => {
+const echo = (content, msg, bot) => {
   if (!msg.member.roles.cache.has(getConsts().role["echo"])) {
     spikeKit.throwErr(msg, "invalidPermsErr");
     return;
   }
-  spikeKit.reply(content, msg);
+  spikeKit.send(content, msg.channelId, bot);
   msg.delete();
 };
 
@@ -284,9 +284,9 @@ function wiki(msg) {
 
 function processCommand(command, args, bot, message) {
   if (command.toLowerCase() === "remindme") remindMe(message, args);
-  else if (command === "embedify") embedify(args, message);
+  else if (command === "embedify") embedify(args, message, bot);
   else if (command === "clear") clear(message);
-  else if (command === "echo") echo(args, message);
+  else if (command === "echo") echo(args, message, bot);
   else if (command === "info") info(message);
   else if (command === "bug") bug(message);
   else if (command === "request") request(message);

--- a/src/plugins/core/main.js
+++ b/src/plugins/core/main.js
@@ -85,7 +85,8 @@ const remindMe = (msg, args) => {
         msg.author.username,
         msg.author.avatarURL()
       ),
-      msg
+      msg,
+      true
     );
   }, time);
 

--- a/src/plugins/enigma/main.js
+++ b/src/plugins/enigma/main.js
@@ -91,7 +91,7 @@ function processCommand(command, args, bot, message) {
     } catch (e) {
       enigmaText = `Error: ${e}`;
     }
-    spikeKit.reply(
+    spikeKit.send(
       spikeKit.createEmbed(
         "Enigma",
         enigmaText,
@@ -99,7 +99,8 @@ function processCommand(command, args, bot, message) {
         message.author.username,
         message.author.avatarURL()
       ),
-      message
+      message.channelId,
+      bot
     );
     message.delete();
   }

--- a/src/plugins/gamble/main.js
+++ b/src/plugins/gamble/main.js
@@ -269,7 +269,7 @@ const leaderboard = (msg) => {
   users.sort((a, b) => b.wallet - a.wallet);
 
   let result = "";
-  for (let i = 0; i < 10; ++i)
+  for (let i = 0; i < 10 && i < users.length; ++i)
     result += `${i + 1} | ${users[i].name} - ${users[i].wallet}\n`;
   result = result.slice(0, result.length - 1);
   const title = "Coin Toss";

--- a/src/plugins/gamble/main.js
+++ b/src/plugins/gamble/main.js
@@ -221,7 +221,6 @@ const coinToss = (msg, prefix) => {
 const gift = (msg) => {
   // gift [amt] [user]
   const args = msg.content.split(" ");
-  console.log(args);
 
   if (args.length != 3) {
     spikeKit.throwErr(msg, "syntax");

--- a/src/plugins/spike-lisp/interpreter.js
+++ b/src/plugins/spike-lisp/interpreter.js
@@ -33,7 +33,7 @@
     },
 
     eval: function (x) {
-      message.channel.send(x[0]);
+      message.channel.send(`${x[0]}`);
       message.delete();
     },
 

--- a/src/slashCommands.js
+++ b/src/slashCommands.js
@@ -6,7 +6,8 @@
 const { getConsts } = require("./faccess.js");
 const Discord = require("discord.js");
 const { REST } = require("@discordjs/rest");
-const { ROUTES } = require("discord-api-types/v9");
+const { Routes } = require("discord-api-types/v9");
+const { SlashCommandBuilder } = require("@discordjs/builders");
 var bot, GUILDID, rest;
 
 const setBot = (theBot) => {
@@ -16,31 +17,20 @@ const setBot = (theBot) => {
 };
 
 /**
- * Add or Update a Command. Passing the name of an existing command updates it.
- * @param {string} name Name of the command
- * @param {string} description Description of the command
- * @param {Object} [options=null] An array of options for the command. See https://discord.com/developers/docs/interactions/slash-commands#registering-a-command
- */
-const addCommand = async (name, description, options = null) => {
-  await rest.put(ROUTES.applicationGuildCommands(bot.user.id, GUILDID), {
-    body: {
-      data: {
-        name: name,
-        description: description,
-        options: options,
-      },
-    },
-  });
-};
-
-/**
  * Delete a command
  * @param {string} commandId The ID of the command to delete
  */
 const deleteCommand = async (commandId) => {
   await rest.delete(
-    `${ROUTES.applicationGuildCommands(bot.user.id, GUILDID)}/${commandId}`
+    `${Routes.applicationGuildCommands(bot.user.id, GUILDID)}/${commandId}`
   );
+};
+
+const getCommands = async () => {
+  let commands = await rest.get(
+    Routes.applicationGuildCommands(bot.user.id, GUILDID)
+  );
+  return commands;
 };
 
 /**
@@ -62,19 +52,37 @@ const reply = async (response, interaction) => {
 /**
  * Bulk add the slash commands we want.
  */
-const addAllCommands = () => {
+const addAllCommands = async () => {
   console.log(`Adding Slash Commands...`);
+  let commands = [];
   const emojis = getConsts().emoji;
   for (let [name, params] of Object.entries(emojis)) {
-    addCommand(
-      name.toLowerCase(),
-      (params.premium
-        ? `[PREMIUM] ${params.content}`
-        : params.content
-      ).substring(0, 100)
+    commands.push(
+      new SlashCommandBuilder()
+        .setName(name.toLowerCase())
+        .setDescription(
+          (params.premium
+            ? `[PREMIUM] ${params.content}`
+            : params.content
+          ).substring(0, 100)
+        )
+        .setDefaultPermission(true)
+        .toJSON()
     );
   }
+  await rest.put(Routes.applicationGuildCommands(bot.user.id, GUILDID), {
+    body: commands,
+  });
   console.log(`All Commands Added.`);
+};
+
+const deleteAllCommands = async () => {
+  const commands = await slashCommands.getCommands();
+  for (command of commands) {
+    console.log(`Deleting ${command.name}...`);
+    await slashCommands.deleteCommand(command.id);
+    console.log(`${command.name} deleted.`);
+  }
 };
 
 /**
@@ -85,15 +93,21 @@ const addAllCommands = () => {
  * Options: [{value: "", type: 4, name: "name"}, ...]
  */
 const handleInteraction = async (interaction, bot) => {
-  const { name, options } = interaction.data;
-  const member = interaction.member;
+  const { commandName, user } = interaction;
+  const member =
+    interaction.guild.members.cache.get(user) ||
+    (await interaction.guild.members.fetch(user));
   const emojiRole = getConsts().role.emoji;
+  let emojiRoleObject =
+    interaction.guild.roles.cache.get(emojiRole) ||
+    (await interaction.guild.roles.fetch(emojiRole));
 
-  const emoji = getConsts().emoji[name];
+  const emoji = getConsts().emoji[commandName];
 
   if (
     emoji &&
-    (!emoji.premium || (emoji.premium && member.roles.includes(emojiRole)))
+    member &&
+    (!emoji.premium || (emoji.premium && member.roles.cache.has(emojiRole)))
   ) {
     reply(emoji.content, interaction);
   }
@@ -102,8 +116,8 @@ const handleInteraction = async (interaction, bot) => {
 module.exports = {
   setBot,
   getCommands,
-  addCommand,
   addAllCommands,
   deleteCommand,
+  deleteAllCommands,
   handleInteraction,
 };

--- a/src/slashCommands.js
+++ b/src/slashCommands.js
@@ -77,10 +77,10 @@ const addAllCommands = async () => {
 };
 
 const deleteAllCommands = async () => {
-  const commands = await slashCommands.getCommands();
+  const commands = await getCommands();
   for (command of commands) {
     console.log(`Deleting ${command.name}...`);
-    await slashCommands.deleteCommand(command.id);
+    await deleteCommand(command.id);
     console.log(`${command.name} deleted.`);
   }
 };

--- a/src/slashCommands.js
+++ b/src/slashCommands.js
@@ -4,6 +4,7 @@
  */
 
 const { getConsts } = require("./faccess.js");
+const Discord = require("discord.js");
 var bot, GUILDID;
 
 const setBot = (theBot) => {
@@ -54,18 +55,18 @@ const deleteCommand = async (commandId) => {
 
 /**
  * Reply to an interaction.
- * @param {string} response Response to send
+ * @param {string | Discord.MessageEmbed} response Response to send
  * @param {Object} interaction The interaction to reply to
  */
-const reply = (response, interaction, bot) => {
-  bot.api.interactions(interaction.id, interaction.token).callback.post({
-    data: {
-      type: 4,
-      data: {
-        content: response,
-      },
-    },
-  });
+const reply = async (response, interaction) => {
+  let messageData = {};
+  if (response instanceof Discord.MessageEmbed) {
+    messageData.embeds = [response];
+  } else {
+    messageData.content = `${response}`;
+  }
+
+  await interaction.reply(messageData);
 };
 
 /**
@@ -104,7 +105,7 @@ const handleInteraction = async (interaction, bot) => {
     emoji &&
     (!emoji.premium || (emoji.premium && member.roles.includes(emojiRole)))
   ) {
-    reply(emoji.content, interaction, bot);
+    reply(emoji.content, interaction);
   }
 };
 

--- a/src/slashCommands.js
+++ b/src/slashCommands.js
@@ -5,28 +5,14 @@
 
 const { getConsts } = require("./faccess.js");
 const Discord = require("discord.js");
-var bot, GUILDID;
+const { REST } = require("@discordjs/rest");
+const { ROUTES } = require("discord-api-types/v9");
+var bot, GUILDID, rest;
 
 const setBot = (theBot) => {
   bot = theBot;
   GUILDID = getConsts().guild;
-};
-
-/**
- * Get the API App object
- * @returns API App required for interacting with the api
- */
-const getApp = () => {
-  return (app = bot.api.applications(bot.user.id).guilds(GUILDID));
-};
-
-/**
- * Get currently enrolled slash commands
- * @returns {Object[]} An array of objects representing slash commands
- */
-const getCommands = async () => {
-  const commands = await getApp().commands.get();
-  return commands;
+  rest = new REST({ version: "9" }).setToken(process.env.DISJS_BOT_TOKEN);
 };
 
 /**
@@ -36,11 +22,13 @@ const getCommands = async () => {
  * @param {Object} [options=null] An array of options for the command. See https://discord.com/developers/docs/interactions/slash-commands#registering-a-command
  */
 const addCommand = async (name, description, options = null) => {
-  await getApp().commands.post({
-    data: {
-      name: name,
-      description: description,
-      options: options,
+  await rest.put(ROUTES.applicationGuildCommands(bot.user.id, GUILDID), {
+    body: {
+      data: {
+        name: name,
+        description: description,
+        options: options,
+      },
     },
   });
 };
@@ -50,7 +38,9 @@ const addCommand = async (name, description, options = null) => {
  * @param {string} commandId The ID of the command to delete
  */
 const deleteCommand = async (commandId) => {
-  await getApp().commands(commandId).delete();
+  await rest.delete(
+    `${ROUTES.applicationGuildCommands(bot.user.id, GUILDID)}/${commandId}`
+  );
 };
 
 /**

--- a/src/spikeKit.js
+++ b/src/spikeKit.js
@@ -111,9 +111,9 @@ function createEmbed(
   }
   return new Discord.MessageEmbed()
     .setColor(color)
-    .setTitle(title)
-    .setDescription(monotype ? "```yaml\n" + content + "\n```" : content)
-    .setFooter(footer, footerImageURL);
+    .setTitle(`${title}`)
+    .setDescription(monotype ? `\`\`\`yaml\n${content}\n\`\`\`` : `${content}`)
+    .setFooter(`${footer}`, footerImageURL);
 }
 
 /**

--- a/src/spikeKit.js
+++ b/src/spikeKit.js
@@ -88,6 +88,7 @@ async function reply(content, message, mention = false) {
 
   messageData.allowedMentions = {};
   messageData.allowedMentions.repliedUser = mention;
+  messageData.failIfNotExists = false;
 
   await message.reply(messageData);
 }

--- a/src/spikeKit.js
+++ b/src/spikeKit.js
@@ -65,10 +65,11 @@ async function send(content, channel, bot) {
  * Reply to an inbound message.
  * @param {Discord.MessageEmbed|String} content The content to include in the message.
  * @param {Discord.Message} message The message object to reply to.
+ * @param {boolean} [mention=false] Mention the user you're replying to.
  * @throws "Embed not provided" if Embed is not properly provided.
  * @throws "Invalid message" if the message object is not properly provided.
  */
-async function reply(content, message) {
+async function reply(content, message, mention = false) {
   if (
     !(content instanceof Discord.MessageEmbed || typeof content === "string")
   ) {
@@ -84,6 +85,9 @@ async function reply(content, message) {
   } else {
     messageData.content = `${content}`;
   }
+
+  messageData.allowedMentions = {};
+  messageData.allowedMentions.repliedUser = mention;
 
   await message.reply(messageData);
 }

--- a/src/spikeKit.js
+++ b/src/spikeKit.js
@@ -48,7 +48,7 @@ async function send(content, channel, bot) {
   if (!(bot instanceof Discord.Client)) {
     throw "Invalid bot";
   }
-  if (!Number.isInteger(channel)) {
+  if (!/\d+/.test(channel)) {
     channel = getChannelID(channel);
   }
 

--- a/src/spikeKit.js
+++ b/src/spikeKit.js
@@ -51,7 +51,14 @@ async function send(content, channel, bot) {
   if (!Number.isInteger(channel)) {
     channel = getChannelID(channel);
   }
-  await bot.channels.cache.get(channel).send(content);
+
+  let messageData = {};
+  if (content instanceof Discord.MessageEmbed) {
+    messageData.embeds = [content];
+  } else {
+    messageData.content = `${content}`;
+  }
+  await bot.channels.cache.get(channel).send(messageData);
 }
 
 /**
@@ -70,7 +77,15 @@ async function reply(content, message) {
   if (!(message instanceof Discord.Message)) {
     throw "Invalid message";
   }
-  await message.channel.send(content);
+
+  let messageData = {};
+  if (content instanceof Discord.MessageEmbed) {
+    messageData.embeds = [content];
+  } else {
+    messageData.content = `${content}`;
+  }
+
+  await message.reply(messageData);
 }
 
 /**


### PR DESCRIPTION
<!-- Thanks for taking the time to work on a patch! Please fill in the following. -->
<!-- We'll be in touch if we need any other information. -->
<!-- Once submitted, follow this PR's progress on the project board. -->
<!-- Notes like this are comments and won't appear in the PR. -->

**Related bugs/feature requests**
<!-- e.g. Resolves #2 -->
<!-- New bullet point for each issue if there's more than one. -->
+ Resolves  #32 

**Describe the changes**
<!-- A clear, concise description of the changes. -->
Upgrades the discord.js version to major version 13. This brings along with it, among others, reply support, slash command support, and thread support. Upgrades to API version 9.

**Expected behavior**
<!-- A clear, concise description of what you expect to happen. -->
Behavior should be the same as it was before.

**Screenshots**
<!-- If applicable, add screenshots to help explain your fix. -->

**New npm dependencies**
<!-- If there are new npm dependencies, list them below with their versions -->
<!-- Make sure changes to package.json and package-lock.json are committed as well -->
+ `discord.js:^13.3.1`
+ `@discordjs/rest:^0.1.0-canary.0`
+ `@discord-api-types:^0.24.0`

**Testing Instructions**
<!-- Instructions to thoroughly test this patch. -->

- [x] Package upgrade
  - [x] `npm ci`
  - [x] Verify that the new version of discord.js is installed: `npm list`
- [x] Slash Commands
  - [x] Uncomment the line in `bot.js` to add all commands.
  - [x] Start Simone. Leave running until all slash commands appear.
  - [x] Make sure they still work by spot checking a few.
  - [x] Stop Simone. Uncomment the delete line in `bot.js` and comment the add line.
  - [x] Start Simone. Leave running until all slash commands are removed.
  - [x] Comment the delete line.
- [x] Message data should now be sent as an object / Strings no longer inferred
  - [x]  Run `%echo`. Verify that the text is sent, not using a reply.
  - [x] Run `%help`. Verify that the embed is sent using a reply.
  - [x] Run `%remindme 00:00:30 this is a test`. Verify first reply has no mention. Leave the channel and verify reminder has a mention.
- [x] Intents must be explicitly passed
  - [x] Other features will not work if this is not set correctly. Nothing new to test. 
- [x] `thingID` becomes `thingId` - Nothing new to test, no instances found that aren't our own objects
- [x] `client.on("messageCreate")` - Nothing new to test
- [x] Make SpikeKit use the `message.reply` function - Tested with previous commands  
- [x] Channel Types change - Nothing new to test until we support DMs again.
- [x] Collections array changes - Not used in codebase 
- [x] `guild.member(user)` deprecation - Not used in codebase
- [x] `hasPermission` deprecation: 
  - [x] Run `%clear 2` and verify that nothing errors out
  - [x] Ask an Administrator to do the same
- [x] `member.lastMessage()` deprecated - Not used in codebase 
- [x] `{start,stop}Typing` deprecated - Not used in codebase

**Additional context**
<!-- Add any other context about the PR here. -->
