### PR TITLE
Ping users using send(); Verify improvements

### DIFF
--- a/consts.json
+++ b/consts.json
@@ -68,7 +68,7 @@
 		"ticketResolved": "***Ticket has been resolved***"
 	},
 	"verify": {
-		"muted-msg": "You have been marked as unverified since you are either new here or you nickname does not meet the server's guidelines. Please read the rules and change your discord nickname to include your first and last name. **After you have done this, type `$verify` to request an unmute!**",
+		"muted-msg": "You have been marked as unverified since you are either new here or you nickname does not meet the server's guidelines. Please read the rules and change your discord nickname to include your first and last name. **After you have done this, type `${PREFIX}verify` to request an unmute!**",
 		"sent-msg": "The admins have been notified about your unmute request!"
 	},
 	"emoji": {

--- a/src/bot.js
+++ b/src/bot.js
@@ -61,7 +61,7 @@ bot.on("messageCreate", async (message) => {
     !message.member.roles.cache.has(getConsts().role["verified"]) &&
     message.channel.id != getConsts().channel.introductions
   ) {
-    verify(message, bot);
+    verify(message, bot, PREFIX);
   }
 
   if (message.channel.type === "DM") {

--- a/src/spikeKit.js
+++ b/src/spikeKit.js
@@ -35,11 +35,12 @@ function getChannelID(channelName) {
  * @param {Discord.MessageEmbed|String} content The content to include in the message.
  * @param {string | int} channel The channel name (without the leading #) or channel ID to send this message to.
  * @param {Discord.Client} bot Instantiated Discord Client.
+ * @param {Discord.User[]} [mention=null] An array of users to mention. Will add to the beginning of the content (even for embeds)
  * @throws "Invalid bot" if the bot is not properly provided.
  * @throws "Embed not provided" if Embed is not properly provided.
  * @throws "Channel not found"  if the given channel name is not in our records.
  */
-async function send(content, channel, bot) {
+async function send(content, channel, bot, mention = false) {
   if (
     !(content instanceof Discord.MessageEmbed || typeof content === "string")
   ) {
@@ -55,8 +56,17 @@ async function send(content, channel, bot) {
   let messageData = {};
   if (content instanceof Discord.MessageEmbed) {
     messageData.embeds = [content];
+    messageData.content = "";
   } else {
     messageData.content = `${content}`;
+  }
+
+  if (mention && mention.length > 0) {
+    let mentionString = "";
+    for (const user of mention) {
+      mentionString += `${user} `;
+    }
+    messageData.content = `${mentionString}${messageData.content}`;
   }
   await bot.channels.cache.get(channel).send(messageData);
 }

--- a/src/verify.js
+++ b/src/verify.js
@@ -1,10 +1,10 @@
 const { getConsts } = require("./faccess.js");
 const spikeKit = require("./spikeKit.js");
 
-const verify = (message, bot) => {
+const verify = (message, bot, PREFIX) => {
   message.delete();
 
-  if (message.content === "$verify") {
+  if (message.content === `${PREFIX}verify`) {
     const e = spikeKit.createEmbed(
       "Request sent!",
       getConsts().verify["sent-msg"],
@@ -13,10 +13,10 @@ const verify = (message, bot) => {
       message.author.avatarURL(),
       spikeKit.COLORS.PURPLE
     );
-    spikeKit.send(e, "bot-commands", bot);
+    spikeKit.send(e, "bot-commands", bot, [message.author]);
 
     const title = `User "${message.author.username}" unmute request`;
-    const content = `<@${message.author.id}> has requested to be unmuted`;
+    const content = `${message.author} has requested to be unmuted`;
     const f = spikeKit.createEmbed(
       title,
       content,
@@ -27,9 +27,10 @@ const verify = (message, bot) => {
     );
     spikeKit.send(f, "admin-notifications", bot);
   } else {
-    const content = `<@${message.author.id}> ${
-      getConsts().verify["muted-msg"]
-    }`;
+    const content = getConsts().verify["muted-msg"].replace(
+      "${PREFIX}",
+      `${PREFIX}`
+    );
     const e = spikeKit.createEmbed(
       "Unverified",
       content,
@@ -38,7 +39,7 @@ const verify = (message, bot) => {
       message.author.avatarURL(),
       spikeKit.COLORS.RED
     );
-    spikeKit.send(e, "bot-commands", bot);
+    spikeKit.send(e, "bot-commands", bot, [message.author]);
   }
 };
 


### PR DESCRIPTION
<!-- Thanks for taking the time to work on a patch! Please fill in the following. -->
<!-- We'll be in touch if we need any other information. -->
<!-- Once submitted, follow this PR's progress on the project board. -->
<!-- Notes like this are comments and won't appear in the PR. -->

**Related bugs/feature requests**
<!-- e.g. Resolves #2 -->
<!-- New bullet point for each issue if there's more than one. -->
+ Resolves  #64 

**Describe the changes**
<!-- A clear, concise description of the changes. -->

- Adds a new argument to `SpikeKit.send()`, an array of `User`s. Appends mentions for these users before the message content (even with embeds) to ping them.
- Verify now uses this feature
- Prefix not hard coded anymore for verify

**Expected behavior**
<!-- A clear, concise description of what you expect to happen. -->

- Verify messages ping the person

**Screenshots**
<!-- If applicable, add screenshots to help explain your fix. -->

**New npm dependencies**
<!-- If there are new npm dependencies, list them below with their versions -->
<!-- Make sure changes to package.json and package-lock.json are committed as well -->

**Testing Instructions**
<!-- Instructions to thoroughly test this patch. -->

- Already tested. See #bot-commands

**Additional context**
<!-- Add any other context about the PR here. -->
