### PR TITLE
Make Discord logging errors non-fatal

### DIFF
--- a/src/SpikeDiscordWebhookTransport.js
+++ b/src/SpikeDiscordWebhookTransport.js
@@ -1,10 +1,17 @@
 const DiscordWebhookTransport = require("@typicalninja21/discord-winston");
+const spikeKit = require("./spikeKit.js");
 
 // prettier-ignore
 module.exports = class SpikeDiscordWebhookTransport extends DiscordWebhookTransport {
   log(info, callback) {
-    if (info.postToDiscord == false) return callback();
-    this.postToWebhook(info);
-    return callback();
+    try {
+      if (info.postToDiscord == false) return callback();
+      this.postToWebhook(info);
+      return callback();
+    } catch (e) {
+      spikeKit.logger.error(`Error occurred trying to log to Discord: ${e.stack}`, {
+        postToDiscord: false,
+      });
+    }
   }
 };


### PR DESCRIPTION
<!-- Thanks for taking the time to work on a patch! Please fill in the following. -->
<!-- We'll be in touch if we need any other information. -->
<!-- Once submitted, follow this PR's progress on the project board. -->
<!-- Notes like this are comments and won't appear in the PR. -->

**Related bugs/feature requests**
<!-- e.g. Resolves #2 -->
<!-- New bullet point for each issue if there's more than one. -->
+ Resolves  #76 

**Describe the changes**
<!-- A clear, concise description of the changes. -->
Wraps Discord logging in a try/catch, then logs exceptions while sending to Discord webhook with a flag to not try to post to Discord.

**Expected behavior**
<!-- A clear, concise description of what you expect to happen. -->
Any errors while logging to Discord should be non-fatal, and the stack trace should be logged to the other transports.

**Screenshots**
<!-- If applicable, add screenshots to help explain your fix. -->

**New npm dependencies**
<!-- If there are new npm dependencies, list them below with their versions -->
<!-- Make sure changes to package.json and package-lock.json are committed as well -->

**Testing Instructions**
<!-- Instructions to thoroughly test this patch. -->
Not easily testable for the exact case we're worried about. What I did to make sure it should work as expected:

1. Added the `catch` body to the `try` body (without trying to print the stack trace).
2. Added an error log on bot start.
3. Started the testing bot.
4. The initial error logged to all transports. The subsequent simulated Discord logging error was only seen in the console and log file.

**Additional context**
<!-- Add any other context about the PR here. -->
