### PR TITLE
Don't start ITS Service Notes when on non-prod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 testing:
 	sed -i 's/PREFIX = "\$$"/PREFIX = "%"/g' src/main.js
-	rm -f plugins/itsServiceNotes/lastCheckTime.txt
 
 resetTesting:
 	sed -i 's/PREFIX = "%"/PREFIX = "\$$"/g' src/main.js

--- a/src/main.js
+++ b/src/main.js
@@ -22,6 +22,8 @@ const winstonRotateFile = require("winston-daily-rotate-file");
 
 const PREFIX = "$";
 
+spikeKit.IS_PROD = !process.argv.includes("--testing");
+
 // Logger setup
 const webhookRegex = new RegExp(
   /^https:\/\/discord.com\/api\/webhooks\/(.+)\/(.+)$/,

--- a/src/plugins/itsServiceNotes/main.js
+++ b/src/plugins/itsServiceNotes/main.js
@@ -31,6 +31,12 @@ const AUTHOR = "Brandon Ingli";
  * @param {Discord.Client} bot Instantiated Discord Bot object.
  */
 function startCron(bot) {
+  if (!spikeKit.IS_PROD) {
+    spikeKit.logger.warn(
+      "ITS Service Notes: Running on non-prod, so not starting cron."
+    );
+    return;
+  }
   const asyncInterval = new AsyncInterval(async function () {
     try {
       const messages = await its.getNewServiceNotes();

--- a/src/spikeKit.js
+++ b/src/spikeKit.js
@@ -5,6 +5,7 @@
 const Discord = require("discord.js");
 const { getConsts, getErrs } = require("./faccess.js");
 let logger;
+let IS_PROD = true;
 
 const COLORS = {
   PURPLE: 0x510c76,
@@ -180,6 +181,7 @@ module.exports = {
   MINUTE,
   HOUR,
   COLORS,
+  IS_PROD,
   send,
   reply,
   createEmbed,


### PR DESCRIPTION
<!-- Thanks for taking the time to work on a patch! Please fill in the following. -->
<!-- We'll be in touch if we need any other information. -->
<!-- Once submitted, follow this PR's progress on the project board. -->
<!-- Notes like this are comments and won't appear in the PR. -->

**Related bugs/feature requests**
<!-- e.g. Resolves #2 -->
<!-- New bullet point for each issue if there's more than one. -->
+ Resolves  #77 

**Describe the changes**
<!-- A clear, concise description of the changes. -->
Adds `spikeKit.IS_PROD`. Service Notes now checks to see if we're running on prod before starting the ITS Service Notes cron.

**Expected behavior**
<!-- A clear, concise description of what you expect to happen. -->
On prod, same behavior as before. On testing, a warning is logged indicating ITS Service Notes didn't start, and notes are not fetched.

**Screenshots**
<!-- If applicable, add screenshots to help explain your fix. -->

**New npm dependencies**
<!-- If there are new npm dependencies, list them below with their versions -->
<!-- Make sure changes to package.json and package-lock.json are committed as well -->

**Testing Instructions**
<!-- Instructions to thoroughly test this patch. -->

- [ ] Start testing
- [ ] Note warning logged

**Additional context**
<!-- Add any other context about the PR here. -->
